### PR TITLE
Session summary

### DIFF
--- a/Dependencies/Topic.swift
+++ b/Dependencies/Topic.swift
@@ -131,9 +131,36 @@ extension Topic {
             title: "Mock topic",
             description: "Just the number 1"
         ),
-        generateQuestion: { _ in
-            Question(topicID: Self.mockID, displayText: "1", spokenText: "1", answerPrefix: nil, answerPostfix: nil, acceptedAnswer: "1")
-        }
+        generateQuestion: { _ in mockQuestion }
+    )
+    static let mockQuestion = Question(topicID: Self.mockID, displayText: "1", spokenText: "1", answerPrefix: nil, answerPostfix: nil, acceptedAnswer: "1")
+    static let mockChallengeCorrect = Challenge(
+        id: UUID(),
+        startDate: .init(timeIntervalSince1970: 0),
+        question: mockQuestion,
+        submissions: [
+            Submission(id: UUID(), date: .init(timeIntervalSince1970: 1), kind: .correct, value: "1"),
+        ]
+    )
+    static let mockChallengeIncorrect = Challenge(
+        id: UUID(),
+        startDate: .init(timeIntervalSince1970: 10),
+        question: mockQuestion,
+        submissions: [
+            Submission(id: UUID(), date: .init(timeIntervalSince1970: 11), kind: .incorrect, value: "3"),
+            Submission(id: UUID(), date: .init(timeIntervalSince1970: 12), kind: .incorrect, value: "2"),
+            Submission(id: UUID(), date: .init(timeIntervalSince1970: 13), kind: .correct, value: "1"),
+        ]
+    )
+    static let mockChallengeSkipped = Challenge(
+        id: UUID(),
+        startDate: .init(timeIntervalSince1970: 20),
+        question: mockQuestion,
+        submissions: [
+            Submission(id: UUID(), date: .init(timeIntervalSince1970: 21), kind: .incorrect, value: "3"),
+            Submission(id: UUID(), date: .init(timeIntervalSince1970: 22), kind: .incorrect, value: "2"),
+            Submission(id: UUID(), date: .init(timeIntervalSince1970: 23), kind: .skip, value: nil),
+        ]
     )
 }
 
@@ -141,10 +168,10 @@ func numberQuestionGenerator(for range: ClosedRange<Int>, by byValue: Int = 1, t
     { rng in
         let byRange = Int(Double(range.lowerBound) / Double(byValue)) ... Int(Double(range.upperBound) / Double(byValue))
         let answer = rng { Int.random(in: byRange, using: &$0) * byValue }
-        
+
         /// Format spoken text without grouping so it's spoken properly.
         let spokenText = answer.formatted(.number.grouping(.never))
-        
+
         /// Format display text with digit separators specified in the user's preferred locale.
         let displayText = answer.formatted(.number.grouping(.automatic))
         let acceptedAnswer = String(answer)
@@ -165,10 +192,10 @@ func moneyGenerator(for range: ClosedRange<Int>, by byValue: Int, topicID: UUID)
         let byRange = Int(Double(range.lowerBound) / Double(byValue)) ... Int(Double(range.upperBound) / Double(byValue))
         let answer = rng { Int.random(in: byRange, using: &$0) * byValue }
         let prefix = "￥"
-        
+
         /// Format spoken text without grouping so it's spoken properly.
         let spokenText = "\(prefix)\(answer.formatted(.number.grouping(.never)))"
-        
+
         /// Format display text with digit separators specified in the user's preferred locale.
         let displayText = "\(prefix)\(answer.formatted(.number.grouping(.automatic)))"
         let acceptedAnswer = String(answer)

--- a/count.xcodeproj/project.pbxproj
+++ b/count.xcodeproj/project.pbxproj
@@ -33,7 +33,7 @@
 		348000E32A9CC0A800E7CCEE /* CountBiki.scnassets in Resources */ = {isa = PBXBuildFile; fileRef = 348000E22A9CC0A800E7CCEE /* CountBiki.scnassets */; };
 		348000E52A9CCD4700E7CCEE /* CountBikiView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348000E42A9CCD4700E7CCEE /* CountBikiView.swift */; };
 		349802222A7BDDF200E352F5 /* IndeterminiteProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349802212A7BDDF200E352F5 /* IndeterminiteProgressView.swift */; };
-		349A81732AF517AD00782538 /* ListeningQuizWrapperFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349A81722AF517AD00782538 /* ListeningQuizWrapperFeature.swift */; };
+		349A81732AF517AD00782538 /* ListeningQuizNavigationFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349A81722AF517AD00782538 /* ListeningQuizNavigationFeature.swift */; };
 		349D047A2A84EB3A008AFD0A /* SettingsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349D04792A84EB3A008AFD0A /* SettingsFeature.swift */; };
 		349D047D2A88E569008AFD0A /* Topic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349D047C2A88E569008AFD0A /* Topic.swift */; };
 		349D04802A88F23F008AFD0A /* TopicSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349D047F2A88F23F008AFD0A /* TopicSettings.swift */; };
@@ -83,7 +83,7 @@
 		348000E22A9CC0A800E7CCEE /* CountBiki.scnassets */ = {isa = PBXFileReference; lastKnownFileType = wrapper.scnassets; path = CountBiki.scnassets; sourceTree = "<group>"; };
 		348000E42A9CCD4700E7CCEE /* CountBikiView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountBikiView.swift; sourceTree = "<group>"; };
 		349802212A7BDDF200E352F5 /* IndeterminiteProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndeterminiteProgressView.swift; sourceTree = "<group>"; };
-		349A81722AF517AD00782538 /* ListeningQuizWrapperFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningQuizWrapperFeature.swift; sourceTree = "<group>"; };
+		349A81722AF517AD00782538 /* ListeningQuizNavigationFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningQuizNavigationFeature.swift; sourceTree = "<group>"; };
 		349D04792A84EB3A008AFD0A /* SettingsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsFeature.swift; sourceTree = "<group>"; };
 		349D047C2A88E569008AFD0A /* Topic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Topic.swift; sourceTree = "<group>"; };
 		349D047F2A88F23F008AFD0A /* TopicSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicSettings.swift; sourceTree = "<group>"; };
@@ -209,7 +209,7 @@
 				344242222ABDD814001E2FC8 /* AppIconFeature.swift */,
 				344242242ABDDEA7001E2FC8 /* TranslyvaniaTierFeature.swift */,
 				340A51CE2A78EC78007DCA0C /* ListeningQuizFeature.swift */,
-				349A81722AF517AD00782538 /* ListeningQuizWrapperFeature.swift */,
+				349A81722AF517AD00782538 /* ListeningQuizNavigationFeature.swift */,
 				34AD2C992AF276DB00422C2B /* SessionSummaryFeature.swift */,
 				3478331E2AA7343A005160DC /* PlanningTopicsFeature.swift */,
 				349D04792A84EB3A008AFD0A /* SettingsFeature.swift */,
@@ -369,7 +369,7 @@
 				340A51CD2A78EC78007DCA0C /* App.swift in Sources */,
 				344242232ABDD814001E2FC8 /* AppIconFeature.swift in Sources */,
 				344242372AC41F9C001E2FC8 /* EquatableError.swift in Sources */,
-				349A81732AF517AD00782538 /* ListeningQuizWrapperFeature.swift in Sources */,
+				349A81732AF517AD00782538 /* ListeningQuizNavigationFeature.swift in Sources */,
 				34276FC42AB5899C00647AE9 /* AboutFeature.swift in Sources */,
 				349D047D2A88E569008AFD0A /* Topic.swift in Sources */,
 			);

--- a/count.xcodeproj/project.pbxproj
+++ b/count.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		349D047D2A88E569008AFD0A /* Topic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349D047C2A88E569008AFD0A /* Topic.swift */; };
 		349D04802A88F23F008AFD0A /* TopicSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349D047F2A88F23F008AFD0A /* TopicSettings.swift */; };
 		34A9749A2A7AB0E600E6F672 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 34A974992A7AB0E600E6F672 /* ComposableArchitecture */; };
+		34AD2C9A2AF276DB00422C2B /* SessionSummaryFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AD2C992AF276DB00422C2B /* SessionSummaryFeature.swift */; };
 		34BDC4952AA58A51001EF005 /* GetMoreVoicesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BDC4942AA58A51001EF005 /* GetMoreVoicesView.swift */; };
 		34BDC4972AA5C2B6001EF005 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BDC4962AA5C2B6001EF005 /* Haptics.swift */; };
 		34E2E3EA2AA8C821002B511A /* TopicsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34E2E3E92AA8C821002B511A /* TopicsFeature.swift */; };
@@ -84,6 +85,7 @@
 		349D04792A84EB3A008AFD0A /* SettingsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsFeature.swift; sourceTree = "<group>"; };
 		349D047C2A88E569008AFD0A /* Topic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Topic.swift; sourceTree = "<group>"; };
 		349D047F2A88F23F008AFD0A /* TopicSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicSettings.swift; sourceTree = "<group>"; };
+		34AD2C992AF276DB00422C2B /* SessionSummaryFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionSummaryFeature.swift; sourceTree = "<group>"; };
 		34BDC4942AA58A51001EF005 /* GetMoreVoicesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetMoreVoicesView.swift; sourceTree = "<group>"; };
 		34BDC4962AA5C2B6001EF005 /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
 		34E2E3E92AA8C821002B511A /* TopicsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsFeature.swift; sourceTree = "<group>"; };
@@ -205,6 +207,7 @@
 				344242222ABDD814001E2FC8 /* AppIconFeature.swift */,
 				344242242ABDDEA7001E2FC8 /* TranslyvaniaTierFeature.swift */,
 				340A51CE2A78EC78007DCA0C /* ListeningQuizFeature.swift */,
+				34AD2C992AF276DB00422C2B /* SessionSummaryFeature.swift */,
 				3478331E2AA7343A005160DC /* PlanningTopicsFeature.swift */,
 				349D04792A84EB3A008AFD0A /* SettingsFeature.swift */,
 				34276FBE2AB34EB600647AE9 /* TextSpeechFeature.swift */,
@@ -342,6 +345,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				340B48D12AE8ACDD0046B31C /* StrokeFillShape.swift in Sources */,
+				34AD2C9A2AF276DB00422C2B /* SessionSummaryFeature.swift in Sources */,
 				344242252ABDDEA7001E2FC8 /* TranslyvaniaTierFeature.swift in Sources */,
 				34E2E3EA2AA8C821002B511A /* TopicsFeature.swift in Sources */,
 				3478331F2AA7343A005160DC /* PlanningTopicsFeature.swift in Sources */,

--- a/count.xcodeproj/project.pbxproj
+++ b/count.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		348000E32A9CC0A800E7CCEE /* CountBiki.scnassets in Resources */ = {isa = PBXBuildFile; fileRef = 348000E22A9CC0A800E7CCEE /* CountBiki.scnassets */; };
 		348000E52A9CCD4700E7CCEE /* CountBikiView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348000E42A9CCD4700E7CCEE /* CountBikiView.swift */; };
 		349802222A7BDDF200E352F5 /* IndeterminiteProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349802212A7BDDF200E352F5 /* IndeterminiteProgressView.swift */; };
+		349A81732AF517AD00782538 /* ListeningQuizWrapperFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349A81722AF517AD00782538 /* ListeningQuizWrapperFeature.swift */; };
 		349D047A2A84EB3A008AFD0A /* SettingsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349D04792A84EB3A008AFD0A /* SettingsFeature.swift */; };
 		349D047D2A88E569008AFD0A /* Topic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349D047C2A88E569008AFD0A /* Topic.swift */; };
 		349D04802A88F23F008AFD0A /* TopicSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 349D047F2A88F23F008AFD0A /* TopicSettings.swift */; };
@@ -82,6 +83,7 @@
 		348000E22A9CC0A800E7CCEE /* CountBiki.scnassets */ = {isa = PBXFileReference; lastKnownFileType = wrapper.scnassets; path = CountBiki.scnassets; sourceTree = "<group>"; };
 		348000E42A9CCD4700E7CCEE /* CountBikiView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountBikiView.swift; sourceTree = "<group>"; };
 		349802212A7BDDF200E352F5 /* IndeterminiteProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndeterminiteProgressView.swift; sourceTree = "<group>"; };
+		349A81722AF517AD00782538 /* ListeningQuizWrapperFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningQuizWrapperFeature.swift; sourceTree = "<group>"; };
 		349D04792A84EB3A008AFD0A /* SettingsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsFeature.swift; sourceTree = "<group>"; };
 		349D047C2A88E569008AFD0A /* Topic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Topic.swift; sourceTree = "<group>"; };
 		349D047F2A88F23F008AFD0A /* TopicSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicSettings.swift; sourceTree = "<group>"; };
@@ -207,6 +209,7 @@
 				344242222ABDD814001E2FC8 /* AppIconFeature.swift */,
 				344242242ABDDEA7001E2FC8 /* TranslyvaniaTierFeature.swift */,
 				340A51CE2A78EC78007DCA0C /* ListeningQuizFeature.swift */,
+				349A81722AF517AD00782538 /* ListeningQuizWrapperFeature.swift */,
 				34AD2C992AF276DB00422C2B /* SessionSummaryFeature.swift */,
 				3478331E2AA7343A005160DC /* PlanningTopicsFeature.swift */,
 				349D04792A84EB3A008AFD0A /* SettingsFeature.swift */,
@@ -366,6 +369,7 @@
 				340A51CD2A78EC78007DCA0C /* App.swift in Sources */,
 				344242232ABDD814001E2FC8 /* AppIconFeature.swift in Sources */,
 				344242372AC41F9C001E2FC8 /* EquatableError.swift in Sources */,
+				349A81732AF517AD00782538 /* ListeningQuizWrapperFeature.swift in Sources */,
 				34276FC42AB5899C00647AE9 /* AboutFeature.swift in Sources */,
 				349D047D2A88E569008AFD0A /* Topic.swift in Sources */,
 			);

--- a/count/Feature/ListeningQuizFeature.swift
+++ b/count/Feature/ListeningQuizFeature.swift
@@ -79,7 +79,7 @@ struct ListeningQuizFeature: Reducer {
         case onTask
         case playbackButtonTapped
         case showAnswerButtonTapped
-        case titleButtonTapped
+        case settingsButtonTapped
 
         enum Delegate: Equatable {
             case wantsToShowSummary(SessionSummaryFeature.State)
@@ -206,7 +206,7 @@ struct ListeningQuizFeature: Reducer {
                 state.challenge.submissions.append(submission)
                 return .none
 
-            case .titleButtonTapped:
+            case .settingsButtonTapped:
                 state.destination = .settings(.init(
                     topicID: state.topicID,
                     speechSettings: state.speechSettings
@@ -395,7 +395,7 @@ struct ListeningQuizView: View {
                     }
                     .buttonStyle(.plain)
                     Button {
-                        viewStore.send(.titleButtonTapped)
+                        viewStore.send(.settingsButtonTapped)
                     } label: {
                         HStack(spacing: 6) {
                             Image(systemName: "gearshape.fill")

--- a/count/Feature/ListeningQuizFeature.swift
+++ b/count/Feature/ListeningQuizFeature.swift
@@ -222,8 +222,7 @@ struct ListeningQuizFeature: Reducer {
             case .titleButtonTapped:
                 state.destination = .settings(.init(
                     topicID: state.topicID,
-                    speechSettings: state.speechSettings,
-                    sessionChallenges: state.completedChallenges
+                    speechSettings: state.speechSettings
                 ))
                 return .none
             }

--- a/count/Feature/ListeningQuizFeature.swift
+++ b/count/Feature/ListeningQuizFeature.swift
@@ -173,7 +173,7 @@ struct ListeningQuizFeature: Reducer {
                 return .none
 
             case .endSessionButtonTapped:
-                state.path.append(.summary(.init()))
+                state.path.append(.summary(.init(topicID: state.topicID, sessionChallenges: state.completedChallenges)))
                 return .none
 
             case .onPlaybackFinished:

--- a/count/Feature/ListeningQuizFeature.swift
+++ b/count/Feature/ListeningQuizFeature.swift
@@ -173,8 +173,14 @@ struct ListeningQuizFeature: Reducer {
                 return .none
 
             case .endSessionButtonTapped:
-                state.path.append(.summary(.init(topicID: state.topicID, sessionChallenges: state.completedChallenges)))
-                return .none
+                if state.completedChallenges.isEmpty && state.challenge.submissions.isEmpty {
+                    return .run { _ in
+                        await dismiss()
+                    }
+                } else {
+                    state.path.append(.summary(.init(topicID: state.topicID, sessionChallenges: state.completedChallenges)))
+                    return .none
+                }
 
             case .onPlaybackFinished:
                 guard state.isSpeaking else { return .none }

--- a/count/Feature/ListeningQuizFeature.swift
+++ b/count/Feature/ListeningQuizFeature.swift
@@ -198,6 +198,11 @@ struct ListeningQuizFeature: Reducer {
             case .onTask:
                 return playBackEffect(state: &state)
 
+            case .path(.element(_, .summary(.delegate(.endSession)))):
+                return .run { _ in
+                    await dismiss()
+                }
+
             case .path:
                 return .none
 

--- a/count/Feature/ListeningQuizNavigationFeature.swift
+++ b/count/Feature/ListeningQuizNavigationFeature.swift
@@ -1,7 +1,7 @@
 import ComposableArchitecture
 import SwiftUI
 
-struct ListeningQuizWrapperFeature: Reducer {
+struct ListeningQuizNavigationFeature: Reducer {
     struct State: Equatable {
         var listeningQuiz: ListeningQuizFeature.State
         var path = StackState<Path.State>()
@@ -95,8 +95,8 @@ struct ListeningQuizWrapperFeature: Reducer {
     }
 }
 
-struct ListeningQuizWrapperView: View {
-    let store: StoreOf<ListeningQuizWrapperFeature>
+struct ListeningQuizNavigationView: View {
+    let store: StoreOf<ListeningQuizNavigationFeature>
 
     var body: some View {
         NavigationStackStore(store.scope(state: \.path, action: { .path($0) })) {
@@ -105,8 +105,8 @@ struct ListeningQuizWrapperView: View {
             switch $0 {
             case .summary:
                 CaseLet(
-                    /ListeningQuizWrapperFeature.Path.State.summary,
-                    action: ListeningQuizWrapperFeature.Path.Action.summary,
+                    /ListeningQuizNavigationFeature.Path.State.summary,
+                    action: ListeningQuizNavigationFeature.Path.Action.summary,
                     then: SessionSummaryView.init(store:)
                 )
             }
@@ -118,9 +118,9 @@ struct ListeningQuizWrapperView: View {
 }
 
 #Preview {
-    ListeningQuizWrapperView(
-        store: Store(initialState: ListeningQuizWrapperFeature.State(topicID: Topic.mockID)) {
-            ListeningQuizWrapperFeature()
+    ListeningQuizNavigationView(
+        store: Store(initialState: ListeningQuizNavigationFeature.State(topicID: Topic.mockID)) {
+            ListeningQuizNavigationFeature()
                 ._printChanges()
         }
     )

--- a/count/Feature/ListeningQuizWrapperFeature.swift
+++ b/count/Feature/ListeningQuizWrapperFeature.swift
@@ -5,11 +5,20 @@ struct ListeningQuizWrapperFeature: Reducer {
     struct State: Equatable {
         var listeningQuiz: ListeningQuizFeature.State
         var path = StackState<Path.State>()
+        @PresentationState var settings: SettingsFeature.State?
+
+        init(topicID: UUID) {
+            @Dependency(\.speechSynthesisSettingsClient) var speechSettingsClient
+            let speechSettings = speechSettingsClient.get()
+
+            listeningQuiz = .init(topicID: topicID, speechSettings: speechSettings)
+        }
     }
 
     enum Action: Equatable {
         case listeningQuiz(ListeningQuizFeature.Action)
         case path(StackAction<Path.State, Path.Action>)
+        case settings(PresentationAction<SettingsFeature.Action>)
     }
 
     struct Path: Reducer {
@@ -29,29 +38,59 @@ struct ListeningQuizWrapperFeature: Reducer {
     }
 
     @Dependency(\.dismiss) var dismiss
+    @Dependency(\.speechSynthesisSettingsClient) var speechSettingsClient
 
     var body: some ReducerOf<Self> {
-        Scope(state: \.listeningQuiz, action: /Action.listeningQuiz) {
-            ListeningQuizFeature()
-        }
-        Reduce { state, action in
-            switch action {
-            case let .listeningQuiz(.delegate(.wantsToShowSummary(summaryState))):
-                state.path.append(.summary(summaryState))
-                return .none
-            case .listeningQuiz:
-                return .none
-            case .path(.element(_, .summary(.delegate(.endSession)))):
-                return .run { _ in
-                    await dismiss()
-                }
+        CombineReducers {
+            Scope(state: \.listeningQuiz, action: /Action.listeningQuiz) {
+                ListeningQuizFeature()
+            }
+            Reduce { state, action in
+                switch action {
+                case .listeningQuiz(.endSessionButtonTapped):
+                    if state.listeningQuiz.completedChallenges.isEmpty, state.listeningQuiz.challenge.submissions.isEmpty {
+                        return .run { _ in await dismiss() }
+                    } else {
+                        state.path.append(.summary(.init(topicID: state.listeningQuiz.topicID, sessionChallenges: state.listeningQuiz.completedChallenges)))
+                        return .none
+                    }
 
-            case .path:
-                return .none
+                case .listeningQuiz(.settingsButtonTapped):
+                    state.settings = .init(topicID: state.listeningQuiz.topicID, speechSettings: state.listeningQuiz.speechSettings)
+                    return .none
+
+                case .listeningQuiz:
+                    return .none
+
+                case .path(.element(_, .summary(.delegate(.endSession)))):
+                    return .run { _ in await dismiss() }
+
+                case .path:
+                    return .none
+
+                case .settings:
+                    return .none
+                }
+            }
+            .ifLet(\.$settings, action: /Action.settings) {
+                SettingsFeature()
+            }
+            .forEach(\.path, action: /Action.path) {
+                Path()
             }
         }
-        .forEach(\.path, action: /Action.path) {
-            Path()
+        .onChange(of: \.settings?.speechSettings) { _, newValue in
+            // Play back speechSettings changes to listeningQuiz and client.
+            Reduce { state, _ in
+                guard let newValue else { return .none }
+                state.listeningQuiz.speechSettings = newValue
+                do {
+                    try speechSettingsClient.set(newValue)
+                } catch {
+                    XCTFail("SpeechSettingsClient unexpectedly failed to write")
+                }
+                return .none
+            }
         }
     }
 }
@@ -72,12 +111,15 @@ struct ListeningQuizWrapperView: View {
                 )
             }
         }
+        .sheet(store: store.scope(state: \.$settings, action: { .settings($0) })) { store in
+            SettingsView(store: store)
+        }
     }
 }
 
 #Preview {
     ListeningQuizWrapperView(
-        store: Store(initialState: ListeningQuizWrapperFeature.State(listeningQuiz: .init(topicID: Topic.mockID))) {
+        store: Store(initialState: ListeningQuizWrapperFeature.State(topicID: Topic.mockID)) {
             ListeningQuizWrapperFeature()
                 ._printChanges()
         }

--- a/count/Feature/ListeningQuizWrapperFeature.swift
+++ b/count/Feature/ListeningQuizWrapperFeature.swift
@@ -1,0 +1,85 @@
+import ComposableArchitecture
+import SwiftUI
+
+struct ListeningQuizWrapperFeature: Reducer {
+    struct State: Equatable {
+        var listeningQuiz: ListeningQuizFeature.State
+        var path = StackState<Path.State>()
+    }
+
+    enum Action: Equatable {
+        case listeningQuiz(ListeningQuizFeature.Action)
+        case path(StackAction<Path.State, Path.Action>)
+    }
+
+    struct Path: Reducer {
+        enum State: Equatable {
+            case summary(SessionSummaryFeature.State)
+        }
+
+        enum Action: Equatable {
+            case summary(SessionSummaryFeature.Action)
+        }
+
+        var body: some ReducerOf<Self> {
+            Scope(state: /State.summary, action: /Action.summary) {
+                SessionSummaryFeature()
+            }
+        }
+    }
+
+    @Dependency(\.dismiss) var dismiss
+
+    var body: some ReducerOf<Self> {
+        Scope(state: \.listeningQuiz, action: /Action.listeningQuiz) {
+            ListeningQuizFeature()
+        }
+        Reduce { state, action in
+            switch action {
+            case let .listeningQuiz(.delegate(.wantsToShowSummary(summaryState))):
+                state.path.append(.summary(summaryState))
+                return .none
+            case .listeningQuiz:
+                return .none
+            case .path(.element(_, .summary(.delegate(.endSession)))):
+                return .run { _ in
+                    await dismiss()
+                }
+
+            case .path:
+                return .none
+            }
+        }
+        .forEach(\.path, action: /Action.path) {
+            Path()
+        }
+    }
+}
+
+struct ListeningQuizWrapperView: View {
+    let store: StoreOf<ListeningQuizWrapperFeature>
+
+    var body: some View {
+        NavigationStackStore(store.scope(state: \.path, action: { .path($0) })) {
+            ListeningQuizView(store: store.scope(state: \.listeningQuiz, action: { .listeningQuiz($0) }))
+        } destination: {
+            switch $0 {
+            case .summary:
+                CaseLet(
+                    /ListeningQuizWrapperFeature.Path.State.summary,
+                    action: ListeningQuizWrapperFeature.Path.Action.summary,
+                    then: SessionSummaryView.init(store:)
+                )
+            }
+        }
+    }
+}
+
+#Preview {
+    ListeningQuizWrapperView(
+        store: Store(initialState: ListeningQuizWrapperFeature.State(listeningQuiz: .init(topicID: Topic.mockID))) {
+            ListeningQuizWrapperFeature()
+                ._printChanges()
+        }
+    )
+}

--- a/count/Feature/SessionSummaryFeature.swift
+++ b/count/Feature/SessionSummaryFeature.swift
@@ -149,7 +149,7 @@ struct SessionSummaryView: View {
 #Preview {
     NavigationStack {
         SessionSummaryView(
-            store: Store(initialState: SessionSummaryFeature.State(topicID: Topic.mockID, sessionChallenges: [])) {
+            store: Store(initialState: SessionSummaryFeature.State(topicID: Topic.mockID, sessionChallenges: [Topic.mockChallengeCorrect, Topic.mockChallengeSkipped, Topic.mockChallengeIncorrect])) {
                 SessionSummaryFeature()
                     ._printChanges()
             }

--- a/count/Feature/SessionSummaryFeature.swift
+++ b/count/Feature/SessionSummaryFeature.swift
@@ -126,10 +126,11 @@ struct SessionSummaryView: View {
                     .font(.headline)
                     .padding(.vertical, 20)
                     .frame(maxWidth: .infinity)
-                    .background { RoundedRectangle(cornerRadius: 16.0).fill(Color(.tertiarySystemBackground)) }
+                    .background {
+                        RoundedRectangle(cornerRadius: 16.0)
+                            .fill(Color(.tertiarySystemBackground).shadow(.drop(color: Color.black.opacity(0.05), radius: 6)))
+                    }
                     .padding(.horizontal, 20)
-                    .compositingGroup()
-                    .shadow(color: Color.black.opacity(0.05), radius: 6)
                 }
                 // TODO: Button: retry session with same settings (if timed session was completed)
             }

--- a/count/Feature/SessionSummaryFeature.swift
+++ b/count/Feature/SessionSummaryFeature.swift
@@ -1,0 +1,35 @@
+import ComposableArchitecture
+import SwiftUI
+
+struct SessionSummaryFeature: Reducer {
+    struct State: Equatable {}
+
+    enum Action: Equatable {}
+
+    @Dependency(\.continuousClock) var clock
+
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {}
+        }
+    }
+}
+
+struct SessionSummaryView: View {
+    let store: StoreOf<SessionSummaryFeature>
+
+    var body: some View {
+        WithViewStore(store, observe: { $0 }) { viewStore in
+            Text("hello")
+        }
+    }
+}
+
+#Preview {
+    SessionSummaryView(
+        store: Store(initialState: SessionSummaryFeature.State()) {
+            SessionSummaryFeature()
+                ._printChanges()
+        }
+    )
+}

--- a/count/Feature/SessionSummaryFeature.swift
+++ b/count/Feature/SessionSummaryFeature.swift
@@ -28,7 +28,7 @@ struct SessionSummaryFeature: Reducer {
 
     enum Action: Equatable {
         case delegate(Delegate)
-        
+
         enum Delegate: Equatable {
             case endSession
         }
@@ -112,23 +112,26 @@ struct SessionSummaryView: View {
                     Text("Results")
                         .font(.subheadline)
                 }
-                
+
                 // TODO: more detailed results
             }
             .safeAreaInset(edge: .bottom) {
                 Button {
                     viewStore.send(.delegate(.endSession))
                 } label: {
-                    Text("End Session")
-                        .font(.title3)
-                        .bold()
-                        .frame(height: 80)
-                        .frame(maxWidth: .infinity)
-                        .background { RoundedRectangle(cornerRadius: 16.0).fill(Color(.tertiarySystemBackground)) }
-                        .padding(.horizontal, 20)
-                        .compositingGroup()
-                        .shadow(color: Color.black.opacity(0.05), radius: 6)
+                    HStack(spacing: 6) {
+                        Image(systemName: "door.right.hand.open")
+                        Text("Back to Topics")
+                    }
+                    .font(.headline)
+                    .padding(.vertical, 20)
+                    .frame(maxWidth: .infinity)
+                    .background { RoundedRectangle(cornerRadius: 16.0).fill(Color(.tertiarySystemBackground)) }
+                    .padding(.horizontal, 20)
+                    .compositingGroup()
+                    .shadow(color: Color.black.opacity(0.05), radius: 6)
                 }
+                // TODO: Button: retry session with same settings (if timed session was completed)
             }
             .navigationBarBackButtonHidden(false) // TODO: hide back button on certain conditions (timer out, questions out)
             .navigationBarTitleDisplayMode(.inline)

--- a/count/Feature/SessionSummaryFeature.swift
+++ b/count/Feature/SessionSummaryFeature.swift
@@ -2,15 +2,49 @@ import ComposableArchitecture
 import SwiftUI
 
 struct SessionSummaryFeature: Reducer {
-    struct State: Equatable {}
+    struct State: Equatable {
+        let topic: Topic
+        let sessionChallenges: [Challenge]
 
-    enum Action: Equatable {}
+        init(topicID: UUID, sessionChallenges: [Challenge]) {
+            @Dependency(\.topicClient.allTopics) var allTopics
+
+            topic = allTopics()[id: topicID]!
+            self.sessionChallenges = sessionChallenges
+        }
+
+        var challengesTotal: Int { sessionChallenges.count }
+        var challengesCorrect: Int {
+            sessionChallenges
+                .filter { $0.submissions.allSatisfy { $0.kind == .correct } }
+                .count
+        }
+        var challengesIncorrect: Int {
+            sessionChallenges
+                .filter { $0.submissions.contains(where: { $0.kind == .incorrect || $0.kind == .skip }) }
+                .count
+        }
+    }
+
+    enum Action: Equatable {
+        case delegate(Delegate)
+        
+        enum Delegate: Equatable {
+            case endSession
+        }
+    }
 
     @Dependency(\.continuousClock) var clock
+    @Dependency(\.hapticsClient) var haptics
 
     var body: some ReducerOf<Self> {
         Reduce { state, action in
-            switch action {}
+            switch action {
+            case .delegate:
+                return .run { send in
+                    await haptics.success()
+                }
+            }
         }
     }
 }
@@ -20,16 +54,102 @@ struct SessionSummaryView: View {
 
     var body: some View {
         WithViewStore(store, observe: { $0 }) { viewStore in
-            Text("hello")
+            List {
+                Section {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("\(viewStore.topic.skill.title): \(viewStore.topic.category.title)")
+                            .font(.headline)
+                        Text(viewStore.topic.title)
+                            .font(.subheadline)
+                        Text(viewStore.topic.description)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .multilineTextAlignment(.leading)
+                    .padding(.vertical, 2)
+                } header: {
+                    Text("Topic")
+                        .font(.subheadline)
+                }
+
+                Section {
+                    HStack {
+                        Image(systemName: "tray.full")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 17)
+                        Text("Total Answers")
+                        Spacer()
+                        Text("\(viewStore.challengesTotal)")
+                            .font(.headline)
+                    }
+                    .listRowInsets(.init(top: 0, leading: 20, bottom: 0, trailing: 20))
+                    HStack {
+                        Image(systemName: "checkmark.circle")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 17)
+                            .foregroundStyle(Color.green)
+                        Text("Correct")
+                        Spacer()
+                        Text("\(viewStore.challengesCorrect)")
+                            .font(.headline)
+                    }
+                    .listRowInsets(.init(top: 0, leading: 40, bottom: 0, trailing: 20))
+                    HStack {
+                        Image(systemName: "xmark.circle")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 17)
+                            .foregroundStyle(Color.red)
+                        Text("Incorrect & skipped")
+                        Spacer()
+                        Text("\(viewStore.challengesIncorrect)")
+                            .font(.headline)
+                    }
+                    .listRowInsets(.init(top: 0, leading: 40, bottom: 0, trailing: 20))
+                } header: {
+                    Text("Results")
+                        .font(.subheadline)
+                }
+                
+                // TODO: more detailed results
+            }
+            .safeAreaInset(edge: .bottom) {
+                Button {
+                    viewStore.send(.delegate(.endSession))
+                } label: {
+                    Text("End Session")
+                        .font(.title3)
+                        .bold()
+                        .frame(height: 80)
+                        .frame(maxWidth: .infinity)
+                        .background { RoundedRectangle(cornerRadius: 16.0).fill(Color(.tertiarySystemBackground)) }
+                        .padding(.horizontal, 20)
+                        .compositingGroup()
+                        .shadow(color: Color.black.opacity(0.05), radius: 6)
+                }
+            }
+            .navigationBarBackButtonHidden(false) // TODO: hide back button on certain conditions (timer out, questions out)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    Text("Session Summary")
+                        .font(.headline)
+                }
+            }
         }
     }
 }
 
 #Preview {
-    SessionSummaryView(
-        store: Store(initialState: SessionSummaryFeature.State()) {
-            SessionSummaryFeature()
-                ._printChanges()
-        }
-    )
+    NavigationStack {
+        SessionSummaryView(
+            store: Store(initialState: SessionSummaryFeature.State(topicID: Topic.mockID, sessionChallenges: [])) {
+                SessionSummaryFeature()
+                    ._printChanges()
+            }
+        )
+    }
+    .fontDesign(.rounded)
 }

--- a/count/Feature/SettingsFeature.swift
+++ b/count/Feature/SettingsFeature.swift
@@ -36,17 +36,12 @@ struct SettingsFeature: Reducer {
 
     enum Action: BindableAction, Equatable {
         case binding(BindingAction<State>)
-        case delegate(Delegate)
         case doneButtonTapped
         case onSceneWillEnterForeground
         case onTask
         case pitchLabelDoubleTapped
         case rateLabelDoubleTapped
         case testVoiceButtonTapped
-
-        enum Delegate: Equatable {
-            case speechSettingsUpdated(SpeechSynthesisSettings)
-        }
     }
 
     @Dependency(\.dismiss) var dismiss
@@ -67,8 +62,6 @@ struct SettingsFeature: Reducer {
                 state.speechSettings.pitchMultiplier = state.rawPitchMultiplier
                 return .none
             case .binding:
-                return .none
-            case .delegate:
                 return .none
             case .doneButtonTapped:
                 return .run { send in
@@ -104,11 +97,6 @@ struct SettingsFeature: Reducer {
                         }
                     }
                 }
-            }
-        }
-        .onChange(of: \.speechSettings) { _, newValue in
-            Reduce { _, _ in
-                .send(.delegate(.speechSettingsUpdated(newValue)))
             }
         }
     }

--- a/count/Feature/TopicsFeature.swift
+++ b/count/Feature/TopicsFeature.swift
@@ -19,7 +19,7 @@ extension TopicCategory {
 
 struct TopicsFeature: Reducer {
     struct State: Equatable {
-        @PresentationState var quiz: ListeningQuizWrapperFeature.State?
+        @PresentationState var quiz: ListeningQuizNavigationFeature.State?
         @PresentationState var about: AboutFeature.State?
         let listeningCategories: IdentifiedArrayOf<TopicCategory>
 
@@ -37,7 +37,7 @@ struct TopicsFeature: Reducer {
     enum Action: Equatable {
         case about(PresentationAction<AboutFeature.Action>)
         case aboutButtonTapped
-        case quiz(PresentationAction<ListeningQuizWrapperFeature.Action>)
+        case quiz(PresentationAction<ListeningQuizNavigationFeature.Action>)
         case topicButtonTapped(UUID)
     }
 
@@ -63,7 +63,7 @@ struct TopicsFeature: Reducer {
             }
         }
         .ifLet(\.$quiz, action: /Action.quiz) {
-            ListeningQuizWrapperFeature()
+            ListeningQuizNavigationFeature()
         }
         .ifLet(\.$about, action: /Action.about) {
             AboutFeature()
@@ -169,7 +169,7 @@ struct TopicsView: View {
         .fullScreenCover(
             store: store.scope(state: \.$quiz, action: { .quiz($0) })
         ) { store in
-            ListeningQuizWrapperView(store: store)
+            ListeningQuizNavigationView(store: store)
         }
         .sheet(
             store: store.scope(state: \.$about, action: { .about($0) })

--- a/count/Feature/TopicsFeature.swift
+++ b/count/Feature/TopicsFeature.swift
@@ -19,7 +19,7 @@ extension TopicCategory {
 
 struct TopicsFeature: Reducer {
     struct State: Equatable {
-        @PresentationState var quiz: ListeningQuizFeature.State?
+        @PresentationState var quiz: ListeningQuizWrapperFeature.State?
         @PresentationState var about: AboutFeature.State?
         let listeningCategories: IdentifiedArrayOf<TopicCategory>
 
@@ -37,7 +37,7 @@ struct TopicsFeature: Reducer {
     enum Action: Equatable {
         case about(PresentationAction<AboutFeature.Action>)
         case aboutButtonTapped
-        case quiz(PresentationAction<ListeningQuizFeature.Action>)
+        case quiz(PresentationAction<ListeningQuizWrapperFeature.Action>)
         case topicButtonTapped(UUID)
     }
 
@@ -58,12 +58,12 @@ struct TopicsFeature: Reducer {
                 return .none
 
             case let .topicButtonTapped(topicID):
-                state.quiz = .init(topicID: topicID)
+                state.quiz = .init(listeningQuiz: .init(topicID: topicID))
                 return .none
             }
         }
         .ifLet(\.$quiz, action: /Action.quiz) {
-            ListeningQuizFeature()
+            ListeningQuizWrapperFeature()
         }
         .ifLet(\.$about, action: /Action.about) {
             AboutFeature()
@@ -169,7 +169,7 @@ struct TopicsView: View {
         .fullScreenCover(
             store: store.scope(state: \.$quiz, action: { .quiz($0) })
         ) { store in
-            ListeningQuizView(store: store)
+            ListeningQuizWrapperView(store: store)
         }
         .sheet(
             store: store.scope(state: \.$about, action: { .about($0) })

--- a/count/Feature/TopicsFeature.swift
+++ b/count/Feature/TopicsFeature.swift
@@ -58,7 +58,7 @@ struct TopicsFeature: Reducer {
                 return .none
 
             case let .topicButtonTapped(topicID):
-                state.quiz = .init(listeningQuiz: .init(topicID: topicID))
+                state.quiz = .init(topicID: topicID)
                 return .none
             }
         }

--- a/countTests/ListeningQuizFeatureTests.swift
+++ b/countTests/ListeningQuizFeatureTests.swift
@@ -18,7 +18,7 @@ struct RandomNumberGeneratorWithSeed: RandomNumberGenerator {
 @MainActor final class ListeningQuizFeatureTests: XCTestCase {
     func testOnAppear() async throws {
         let speechExpectation = expectation(description: "speaks")
-        let store = TestStore(initialState: ListeningQuizFeature.State(topicID: Topic.mockID)) {
+        let store = TestStore(initialState: ListeningQuizFeature.State(topicID: Topic.mockID, speechSettings: .mock)) {
             ListeningQuizFeature()
         } withDependencies: {
             $0.topicClient = .mock


### PR DESCRIPTION
- Add session summary screen
- Add `ListeningQuizNavigationFeature` and move navigation handling into it.

## Summary

In preparation for adding time/question attack modes, this PR adds a session summary screen.

While in a session, tapping "End Session" takes you to the session summary. Here, you can either return to the quiz or end the session and return to the topics screen.

I wanted to use a navigation stack for the end session screen rather than push another sheet (although both would work fine). Adding a navigation stack store directly to `ListeningQuizView` seemed to work okay, but actually broke the focus state of the keyboard being activated on view appear. I realized that it'd probably be best to have a wrapper view and feature for handling navigation.

I then moved the setting sheet to the navigation layer as well and reconfigured some of the communication between layers. This includes:

- observing the button taps from the listening quiz within the navigation layer.
- observing changes to the speechSettings from navigation and replaying them to the listening quiz and persistence client.

## Screenshots

<img width="50%" src="https://github.com/twocentstudios/count-biki/assets/603478/c0cebf6b-9c53-48b0-9e5a-269c70203af2">

https://github.com/twocentstudios/count-biki/assets/603478/8ca89b62-1a74-45fb-a301-a220abf53e4b

