### PR TITLE
Refactor SpeechSettings into child Feature

### DIFF
--- a/Dependencies/SessionSettings.swift
+++ b/Dependencies/SessionSettings.swift
@@ -39,7 +39,7 @@ extension SessionSettings {
 }
 
 extension SessionSettingsClient: DependencyKey {
-    static let settingsKey = "SessionSettingsClient.settings"
+    static let settingsKey = "SessionSettingsClient_Settings"
     static var liveValue: Self {
         @Dependency(\.userDefaults) var userDefaults
         @Dependency(\.encode) var encode

--- a/Dependencies/SpeechSynthesisSettings.swift
+++ b/Dependencies/SpeechSynthesisSettings.swift
@@ -1,15 +1,11 @@
+import AsyncExtensions
 import DependenciesAdditions
 import Foundation
 
 struct SpeechSynthesisSettingsClient {
     var get: @Sendable () -> (SpeechSynthesisSettings)
     var set: @Sendable (SpeechSynthesisSettings) throws -> Void
-}
-
-extension SpeechSynthesisSettingsClient {
-    enum Error: Swift.Error {
-        case settingsUnset
-    }
+    var observe: @Sendable () -> AsyncStream<SpeechSynthesisSettings>
 }
 
 extension SpeechSynthesisSettingsClient: DependencyKey {
@@ -36,6 +32,15 @@ extension SpeechSynthesisSettingsClient: DependencyKey {
             set: { newSettings in
                 let data = try encode(newSettings)
                 userDefaults.set(data, forKey: settingsKey)
+            },
+            observe: {
+                userDefaults.dataValues(forKey: settingsKey)
+                    .compactMap { maybeData in
+                        guard let data = maybeData else { return nil }
+                        guard let value = try? decode(SpeechSynthesisSettings.self, from: data) else { return nil }
+                        return value
+                    }
+                    .eraseToStream()
             }
         )
     }
@@ -43,18 +48,20 @@ extension SpeechSynthesisSettingsClient: DependencyKey {
 
 extension SpeechSynthesisSettingsClient: TestDependencyKey {
     static var previewValue: Self {
-        let storage = LockIsolated(SpeechSynthesisSettings.mockNil)
+        let storage = AsyncCurrentValueSubject(SpeechSynthesisSettings.mockNil)
         return .init(
             get: { storage.value },
-            set: { storage.setValue($0) }
+            set: { storage.send($0) },
+            observe: { storage.eraseToStream() }
         )
     }
 
     static var testValue: Self {
-        let storage = LockIsolated(SpeechSynthesisSettings.mockNil)
+        let storage = AsyncCurrentValueSubject(SpeechSynthesisSettings.mockNil)
         return .init(
             get: { storage.value },
-            set: { storage.setValue($0) }
+            set: { storage.send($0) },
+            observe: { storage.eraseToStream() }
         )
     }
 }

--- a/Dependencies/SpeechSynthesisSettings.swift
+++ b/Dependencies/SpeechSynthesisSettings.swift
@@ -4,7 +4,7 @@ import Foundation
 
 struct SpeechSynthesisSettingsClient {
     var get: @Sendable () -> (SpeechSynthesisSettings)
-    var set: @Sendable (SpeechSynthesisSettings) throws -> Void
+    var set: @Sendable (SpeechSynthesisSettings) async throws -> Void
     var observe: @Sendable () -> AsyncStream<SpeechSynthesisSettings>
 }
 

--- a/Dependencies/SpeechSynthesisSettings.swift
+++ b/Dependencies/SpeechSynthesisSettings.swift
@@ -13,14 +13,19 @@ extension SpeechSynthesisSettingsClient {
 }
 
 extension SpeechSynthesisSettingsClient: DependencyKey {
-    static let settingsKey = "SpeechSynthesisSettingsClient.Settings"
+    static let deprecatedSettingsKey = "SpeechSynthesisSettingsClient.Settings"
+    static let settingsKey = "SpeechSynthesisSettingsClient_Settings"
     static var liveValue: Self {
         @Dependency(\.userDefaults) var userDefaults
         @Dependency(\.encode) var encode
         @Dependency(\.decode) var decode
         return .init(
             get: {
-                guard let data = userDefaults.data(forKey: settingsKey) else { return SpeechSynthesisSettings() }
+                guard
+                    let data = userDefaults.data(forKey: settingsKey) ?? userDefaults.data(forKey: deprecatedSettingsKey)
+                else {
+                    return SpeechSynthesisSettings()
+                }
                 do {
                     let value = try decode(SpeechSynthesisSettings.self, from: data)
                     return value

--- a/Dependencies/TierPurchaseHistory.swift
+++ b/Dependencies/TierPurchaseHistory.swift
@@ -7,14 +7,19 @@ struct TierPurchaseHistoryClient {
 }
 
 extension TierPurchaseHistoryClient: DependencyKey {
-    static let key = "TierPurchaseHistoryClient.purchaseHistory"
+    static let deprecatedKey = "TierPurchaseHistoryClient.purchaseHistory"
+    static let key = "TierPurchaseHistoryClient_PurchaseHistory"
     static var liveValue: Self {
         @Dependency(\.userDefaults) var userDefaults
         @Dependency(\.encode) var encode
         @Dependency(\.decode) var decode
         return .init(
             get: {
-                guard let data = userDefaults.data(forKey: key) else { return TierPurchaseHistory() }
+                guard
+                    let data = userDefaults.data(forKey: key) ?? userDefaults.data(forKey: deprecatedKey)
+                else {
+                    return TierPurchaseHistory()
+                }
                 do {
                     let value = try decode(TierPurchaseHistory.self, from: data)
                     return value

--- a/count.xcodeproj/project.pbxproj
+++ b/count.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		34AD2C9A2AF276DB00422C2B /* SessionSummaryFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AD2C992AF276DB00422C2B /* SessionSummaryFeature.swift */; };
 		34BDC4952AA58A51001EF005 /* GetMoreVoicesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BDC4942AA58A51001EF005 /* GetMoreVoicesView.swift */; };
 		34BDC4972AA5C2B6001EF005 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BDC4962AA5C2B6001EF005 /* Haptics.swift */; };
+		34BE3F682AFA7C4C002AD0F3 /* SpeechSettingsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BE3F672AFA7C4C002AD0F3 /* SpeechSettingsFeature.swift */; };
 		34E2E3EA2AA8C821002B511A /* TopicsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34E2E3E92AA8C821002B511A /* TopicsFeature.swift */; };
 		34E2E3EE2AA9C86A002B511A /* ConfettiSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 34E2E3ED2AA9C86A002B511A /* ConfettiSwiftUI */; };
 		34E53DC42AF793DC007E4BAE /* DeterminiteProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34E53DC32AF793DC007E4BAE /* DeterminiteProgressView.swift */; };
@@ -93,6 +94,7 @@
 		34AD2C992AF276DB00422C2B /* SessionSummaryFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionSummaryFeature.swift; sourceTree = "<group>"; };
 		34BDC4942AA58A51001EF005 /* GetMoreVoicesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetMoreVoicesView.swift; sourceTree = "<group>"; };
 		34BDC4962AA5C2B6001EF005 /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
+		34BE3F672AFA7C4C002AD0F3 /* SpeechSettingsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechSettingsFeature.swift; sourceTree = "<group>"; };
 		34E2E3E92AA8C821002B511A /* TopicsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsFeature.swift; sourceTree = "<group>"; };
 		34E53DC32AF793DC007E4BAE /* DeterminiteProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeterminiteProgressView.swift; sourceTree = "<group>"; };
 		34E53DC52AF7AD32007E4BAE /* Clamped.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Clamped.swift; sourceTree = "<group>"; };
@@ -220,6 +222,7 @@
 				34AD2C992AF276DB00422C2B /* SessionSummaryFeature.swift */,
 				3478331E2AA7343A005160DC /* PlanningTopicsFeature.swift */,
 				349D04792A84EB3A008AFD0A /* SettingsFeature.swift */,
+				34BE3F672AFA7C4C002AD0F3 /* SpeechSettingsFeature.swift */,
 				34276FBE2AB34EB600647AE9 /* TextSpeechFeature.swift */,
 				34E2E3E92AA8C821002B511A /* TopicsFeature.swift */,
 				34E53DC72AF7C2D8007E4BAE /* PreSettingsFeature.swift */,
@@ -379,6 +382,7 @@
 				340E70532A820E73004B124B /* SpeechSynthesis.swift in Sources */,
 				340A51CD2A78EC78007DCA0C /* App.swift in Sources */,
 				344242232ABDD814001E2FC8 /* AppIconFeature.swift in Sources */,
+				34BE3F682AFA7C4C002AD0F3 /* SpeechSettingsFeature.swift in Sources */,
 				344242372AC41F9C001E2FC8 /* EquatableError.swift in Sources */,
 				349A81732AF517AD00782538 /* ListeningQuizNavigationFeature.swift in Sources */,
 				34276FC42AB5899C00647AE9 /* AboutFeature.swift in Sources */,

--- a/count/Feature/ListeningQuizFeature.swift
+++ b/count/Feature/ListeningQuizFeature.swift
@@ -243,7 +243,7 @@ struct ListeningQuizFeature: Reducer {
                             await send(.onSpeechSettingsUpdated(newValue))
                         }
                     })
-                    
+
             case .onTimerTick:
                 if applicationState == .active {
                     state.secondsElapsed += 1

--- a/count/Feature/ListeningQuizNavigationFeature.swift
+++ b/count/Feature/ListeningQuizNavigationFeature.swift
@@ -65,7 +65,7 @@ struct ListeningQuizNavigationFeature: Reducer {
                     }
 
                 case .listeningQuiz(.settingsButtonTapped):
-                    state.settings = .init(topicID: state.listeningQuiz.topicID, speechSettings: state.listeningQuiz.speechSettings)
+                    state.settings = .init(topicID: state.listeningQuiz.topicID)
                     return .none
 
                 case .listeningQuiz(.answerSubmitButtonTapped):
@@ -99,19 +99,19 @@ struct ListeningQuizNavigationFeature: Reducer {
                 Path()
             }
         }
-        .onChange(of: \.settings?.speechSettings) { _, newValue in
-            // Play back speechSettings changes to listeningQuiz and client.
-            Reduce { state, _ in
-                guard let newValue else { return .none }
-                state.listeningQuiz.speechSettings = newValue
-                do {
-                    try speechSettingsClient.set(newValue)
-                } catch {
-                    XCTFail("SpeechSettingsClient unexpectedly failed to write")
-                }
-                return .none
-            }
-        }
+//        .onChange(of: \.settings?.speechSettings) { _, newValue in
+//            // Play back speechSettings changes to listeningQuiz and client.
+//            Reduce { state, _ in
+//                guard let newValue else { return .none }
+//                state.listeningQuiz.speechSettings = newValue
+//                do {
+//                    try speechSettingsClient.set(newValue)
+//                } catch {
+//                    XCTFail("SpeechSettingsClient unexpectedly failed to write")
+//                }
+//                return .none
+//            }
+//        }
     }
 }
 

--- a/count/Feature/ListeningQuizNavigationFeature.swift
+++ b/count/Feature/ListeningQuizNavigationFeature.swift
@@ -8,12 +8,10 @@ struct ListeningQuizNavigationFeature: Reducer {
         @PresentationState var settings: SettingsFeature.State?
 
         init(topicID: UUID) {
-            @Dependency(\.speechSynthesisSettingsClient) var speechSettingsClient
-            let speechSettings = speechSettingsClient.get()
             @Dependency(\.sessionSettingsClient) var sessionSettingsClient
             let sessionSettings = sessionSettingsClient.get()
 
-            listeningQuiz = .init(topicID: topicID, quizMode: .init(sessionSettings), speechSettings: speechSettings)
+            listeningQuiz = .init(topicID: topicID, quizMode: .init(sessionSettings))
         }
     }
 
@@ -40,7 +38,6 @@ struct ListeningQuizNavigationFeature: Reducer {
     }
 
     @Dependency(\.dismiss) var dismiss
-    @Dependency(\.speechSynthesisSettingsClient) var speechSettingsClient
 
     var body: some ReducerOf<Self> {
         CombineReducers {
@@ -99,19 +96,6 @@ struct ListeningQuizNavigationFeature: Reducer {
                 Path()
             }
         }
-//        .onChange(of: \.settings?.speechSettings) { _, newValue in
-//            // Play back speechSettings changes to listeningQuiz and client.
-//            Reduce { state, _ in
-//                guard let newValue else { return .none }
-//                state.listeningQuiz.speechSettings = newValue
-//                do {
-//                    try speechSettingsClient.set(newValue)
-//                } catch {
-//                    XCTFail("SpeechSettingsClient unexpectedly failed to write")
-//                }
-//                return .none
-//            }
-//        }
     }
 }
 

--- a/count/Feature/PreSettingsFeature.swift
+++ b/count/Feature/PreSettingsFeature.swift
@@ -4,22 +4,14 @@ import SwiftUI
 
 struct PreSettingsFeature: Reducer {
     struct State: Equatable {
-        var availableVoices: [SpeechSynthesisVoice]
         @BindingState var rawQuizMode: SessionSettings.QuizMode
         @BindingState var rawQuestionLimit: Int
         @BindingState var rawTimeLimit: Int
-        @BindingState var rawSpeechRate: Float
-        @BindingState var rawVoiceIdentifier: String?
-        @BindingState var rawPitchMultiplier: Float
-        let pitchMultiplierRange: ClosedRange<Float>
-        let speechRateRange: ClosedRange<Float>
-        var speechSettings: SpeechSynthesisSettings
+        var speechSettings: SpeechSettingsFeature.State
         var sessionSettings: SessionSettings
 
-        init() {
+        init(speechSettings: SpeechSettingsFeature.State = .init()) {
             @Dependency(\.sessionSettingsClient) var sessionSettingsClient
-            @Dependency(\.speechSynthesisSettingsClient) var speechSettingsClient
-            @Dependency(\.speechSynthesisClient) var speechClient
             @Dependency(\.topicClient.allTopics) var allTopics
 
             sessionSettings = sessionSettingsClient.get()
@@ -27,37 +19,24 @@ struct PreSettingsFeature: Reducer {
             rawQuestionLimit = sessionSettings.questionLimit // TODO: validate input
             rawTimeLimit = sessionSettings.timeLimit // TODO: validate input
 
-            speechSettings = speechSettingsClient.get()
-
-            availableVoices = speechClient.availableVoices()
-            rawVoiceIdentifier = speechSettings.voiceIdentifier ?? speechClient.defaultVoice()?.voiceIdentifier
-
-            let speechRateAttributes = speechClient.speechRateAttributes()
-            rawSpeechRate = speechSettings.rate ?? speechRateAttributes.defaultRate
-            speechRateRange = speechRateAttributes.minimumRate ... speechRateAttributes.maximumRate
-
-            let pitchMultiplierAttributes = speechClient.pitchMultiplierAttributes()
-            rawPitchMultiplier = speechSettings.pitchMultiplier ?? pitchMultiplierAttributes.defaultPitch
-            pitchMultiplierRange = pitchMultiplierAttributes.minimumPitch ... pitchMultiplierAttributes.maximumPitch
+            self.speechSettings = speechSettings
         }
     }
 
     enum Action: BindableAction, Equatable {
         case binding(BindingAction<State>)
-        case onSceneWillEnterForeground
         case onTask
-        case pitchLabelDoubleTapped
-        case rateLabelDoubleTapped
-        case testVoiceButtonTapped
+        case speechSettings(SpeechSettingsFeature.Action)
     }
 
-    @Dependency.Notification(\.sceneWillEnterForeground) var sceneWillEnterForeground
     @Dependency(\.speechSynthesisClient) var speechClient
     @Dependency(\.sessionSettingsClient) var sessionSettingsClient
-    @Dependency(\.speechSynthesisSettingsClient) var speechSettingsClient
 
     var body: some ReducerOf<Self> {
         BindingReducer()
+        Scope(state: \.speechSettings, action: /Action.speechSettings) {
+            SpeechSettingsFeature()
+        }
         Reduce { state, action in
             switch action {
             case .binding(\.$rawQuizMode):
@@ -69,47 +48,12 @@ struct PreSettingsFeature: Reducer {
             case .binding(\.$rawTimeLimit):
                 state.sessionSettings.timeLimit = state.rawTimeLimit
                 return .none
-            case .binding(\.$rawSpeechRate):
-                state.speechSettings.rate = state.rawSpeechRate
-                return .none
-            case .binding(\.$rawVoiceIdentifier):
-                state.speechSettings.voiceIdentifier = state.rawVoiceIdentifier
-                return .none
-            case .binding(\.$rawPitchMultiplier):
-                state.speechSettings.pitchMultiplier = state.rawPitchMultiplier
-                return .none
             case .binding:
                 return .none
-            case .pitchLabelDoubleTapped:
-                state.rawPitchMultiplier = speechClient.pitchMultiplierAttributes().defaultPitch
-                state.speechSettings.pitchMultiplier = state.rawPitchMultiplier
-                return .none
-            case .rateLabelDoubleTapped:
-                state.rawSpeechRate = speechClient.speechRateAttributes().defaultRate
-                state.speechSettings.rate = state.rawSpeechRate
-                return .none
-            case .onSceneWillEnterForeground:
-                state.availableVoices = speechClient.availableVoices()
-                return .none
             case .onTask:
-                return .run { send in
-                    for await _ in sceneWillEnterForeground {
-                        await send(.onSceneWillEnterForeground)
-                    }
-                }
-            case .testVoiceButtonTapped:
-                let spokenText = "1234"
-                enum CancelID { case speakAction }
-                return .run { [settings = state.speechSettings] send in
-                    await withTaskCancellation(id: CancelID.speakAction, cancelInFlight: true) {
-                        do {
-                            let utterance = SpeechSynthesisUtterance(speechString: spokenText, settings: settings)
-                            try await speechClient.speak(utterance)
-                        } catch {
-                            assertionFailure(error.localizedDescription)
-                        }
-                    }
-                }
+                return .send(.speechSettings(.onTask))
+            case .speechSettings:
+                return .none
             }
         }
         .onChange(of: \.sessionSettings) { _, newValue in
@@ -118,16 +62,6 @@ struct PreSettingsFeature: Reducer {
                     try sessionSettingsClient.set(newValue)
                 } catch {
                     XCTFail("SessionSettingsClient unexpectedly failed to write")
-                }
-                return .none
-            }
-        }
-        .onChange(of: \.speechSettings) { _, newValue in
-            Reduce { _, _ in
-                do {
-                    try speechSettingsClient.set(newValue)
-                } catch {
-                    XCTFail("SpeechSettingsClient unexpectedly failed to write")
                 }
                 return .none
             }
@@ -183,71 +117,9 @@ struct PreSettingsView: View {
                     }
                     .listRowBackground(Color(.tertiarySystemBackground))
 
-                    Section {
-                        if let $unwrappedVoiceIdentifier = Binding(viewStore.$rawVoiceIdentifier) {
-                            Picker(selection: $unwrappedVoiceIdentifier) {
-                                ForEach(viewStore.availableVoices) { voice in
-                                    Text(voice.name)
-                                        .tag(Optional(voice.voiceIdentifier))
-                                }
-                            } label: {
-                                Text("Voice name")
-                            }
-                            .pickerStyle(.navigationLink)
-                            NavigationLink {
-                                GetMoreVoicesView()
-                            } label: {
-                                Text("Get more voices")
-                            }
-                            HStack {
-                                Text("Rate")
-                                    .onTapGesture(count: 2) {
-                                        viewStore.send(.rateLabelDoubleTapped)
-                                    }
-                                Slider(value: viewStore.$rawSpeechRate, in: viewStore.speechRateRange, step: 0.05) {
-                                    Text("Speech rate")
-                                } minimumValueLabel: {
-                                    Image(systemName: "tortoise")
-                                } maximumValueLabel: {
-                                    Image(systemName: "hare")
-                                }
-                            }
-                            HStack {
-                                Text("Pitch")
-                                    .onTapGesture(count: 2) {
-                                        viewStore.send(.pitchLabelDoubleTapped)
-                                    }
-                                Slider(value: viewStore.$rawPitchMultiplier, in: viewStore.pitchMultiplierRange, step: 0.05) {
-                                    Text("Pitch")
-                                } minimumValueLabel: {
-                                    Image(systemName: "dial.low")
-                                } maximumValueLabel: {
-                                    Image(systemName: "dial.high")
-                                }
-                            }
-                            Button {
-                                viewStore.send(.testVoiceButtonTapped)
-                            } label: {
-                                HStack(spacing: 10) {
-                                    Image(systemName: "person.wave.2")
-                                    Text("Test Voice")
-                                }
-                                .frame(maxWidth: .infinity, alignment: .center)
-                            }
-                        } else {
-                            NavigationLink {
-                                GetMoreVoicesView()
-                            } label: {
-                                HStack {
-                                    Text("Error: no voices found on device")
-                                        .foregroundStyle(Color.red)
-                                }
-                            }
-                        }
-                    } header: {
-                        Text("Voice Settings")
-                            .font(.subheadline)
-                    }
+                    SpeechSettingsSection(
+                        store: store.scope(state: \.speechSettings, action: { .speechSettings($0) })
+                    )
                     .listRowBackground(Color(.systemGroupedBackground))
                 }
                 .scrollContentBackground(.hidden)

--- a/count/Feature/SettingsFeature.swift
+++ b/count/Feature/SettingsFeature.swift
@@ -3,40 +3,28 @@ import SwiftUI
 
 struct SettingsFeature: Reducer {
     struct State: Equatable {
-        var speechSettings: SpeechSettingsFeature.State
-
         let topic: Topic
 
-        init(topicID: UUID, speechSettings: SpeechSettingsFeature.State = .init()) {
+        init(topicID: UUID) {
             @Dependency(\.topicClient.allTopics) var allTopics
 
             topic = allTopics()[id: topicID]!
-            self.speechSettings = speechSettings
         }
     }
 
     enum Action: Equatable {
         case doneButtonTapped
-        case onTask
-        case speechSettings(SpeechSettingsFeature.Action)
     }
 
     @Dependency(\.dismiss) var dismiss
 
     var body: some ReducerOf<Self> {
-        Scope(state: \.speechSettings, action: /Action.speechSettings) {
-            SpeechSettingsFeature()
-        }
         Reduce { state, action in
             switch action {
             case .doneButtonTapped:
                 return .run { send in
                     await dismiss()
                 }
-            case .onTask:
-                return .send(.speechSettings(.onTask))
-            case .speechSettings:
-                return .none
             }
         }
     }
@@ -67,8 +55,9 @@ struct SettingsView: View {
                     }
 
                     SpeechSettingsSection(
-                        store: store.scope(state: \.speechSettings, action: { .speechSettings($0) })
-                    )
+                        store: Store(initialState: .init()) {
+                            SpeechSettingsFeature()
+                        })
                 }
                 .navigationBarTitleDisplayMode(.inline)
                 .navigationTitle("Session")
@@ -86,9 +75,6 @@ struct SettingsView: View {
                         }
                     }
                 }
-            }
-            .task {
-                await viewStore.send(.onTask).finish()
             }
         }
     }

--- a/count/Feature/SettingsFeature.swift
+++ b/count/Feature/SettingsFeature.swift
@@ -1,4 +1,3 @@
-import _NotificationDependency
 import ComposableArchitecture
 import SwiftUI
 

--- a/count/Feature/SettingsFeature.swift
+++ b/count/Feature/SettingsFeature.swift
@@ -4,99 +4,41 @@ import SwiftUI
 
 struct SettingsFeature: Reducer {
     struct State: Equatable {
-        var availableVoices: [SpeechSynthesisVoice]
-        @BindingState var rawSpeechRate: Float
-        @BindingState var rawVoiceIdentifier: String?
-        @BindingState var rawPitchMultiplier: Float
-        let pitchMultiplierRange: ClosedRange<Float>
-        let speechRateRange: ClosedRange<Float>
-        var speechSettings: SpeechSynthesisSettings
+        var speechSettings: SpeechSettingsFeature.State
 
         let topic: Topic
 
-        init(topicID: UUID, speechSettings: SpeechSynthesisSettings) {
+        init(topicID: UUID, speechSettings: SpeechSettingsFeature.State = .init()) {
             @Dependency(\.speechSynthesisClient) var speechClient
             @Dependency(\.topicClient.allTopics) var allTopics
 
             topic = allTopics()[id: topicID]!
             self.speechSettings = speechSettings
-
-            availableVoices = speechClient.availableVoices()
-            rawVoiceIdentifier = speechSettings.voiceIdentifier ?? speechClient.defaultVoice()?.voiceIdentifier
-
-            let speechRateAttributes = speechClient.speechRateAttributes()
-            rawSpeechRate = speechSettings.rate ?? speechRateAttributes.defaultRate
-            speechRateRange = speechRateAttributes.minimumRate ... speechRateAttributes.maximumRate
-
-            let pitchMultiplierAttributes = speechClient.pitchMultiplierAttributes()
-            rawPitchMultiplier = speechSettings.pitchMultiplier ?? pitchMultiplierAttributes.defaultPitch
-            pitchMultiplierRange = pitchMultiplierAttributes.minimumPitch ... pitchMultiplierAttributes.maximumPitch
         }
     }
 
-    enum Action: BindableAction, Equatable {
-        case binding(BindingAction<State>)
+    enum Action: Equatable {
         case doneButtonTapped
-        case onSceneWillEnterForeground
         case onTask
-        case pitchLabelDoubleTapped
-        case rateLabelDoubleTapped
-        case testVoiceButtonTapped
+        case speechSettings(SpeechSettingsFeature.Action)
     }
 
     @Dependency(\.dismiss) var dismiss
-    @Dependency.Notification(\.sceneWillEnterForeground) var sceneWillEnterForeground
-    @Dependency(\.speechSynthesisClient) var speechClient
 
     var body: some ReducerOf<Self> {
-        BindingReducer()
+        Scope(state: \.speechSettings, action: /Action.speechSettings) {
+            SpeechSettingsFeature()
+        }
         Reduce { state, action in
             switch action {
-            case .binding(\.$rawSpeechRate):
-                state.speechSettings.rate = state.rawSpeechRate
-                return .none
-            case .binding(\.$rawVoiceIdentifier):
-                state.speechSettings.voiceIdentifier = state.rawVoiceIdentifier
-                return .none
-            case .binding(\.$rawPitchMultiplier):
-                state.speechSettings.pitchMultiplier = state.rawPitchMultiplier
-                return .none
-            case .binding:
-                return .none
             case .doneButtonTapped:
                 return .run { send in
                     await dismiss()
                 }
-            case .pitchLabelDoubleTapped:
-                state.rawPitchMultiplier = speechClient.pitchMultiplierAttributes().defaultPitch
-                state.speechSettings.pitchMultiplier = state.rawPitchMultiplier
-                return .none
-            case .rateLabelDoubleTapped:
-                state.rawSpeechRate = speechClient.speechRateAttributes().defaultRate
-                state.speechSettings.rate = state.rawSpeechRate
-                return .none
-            case .onSceneWillEnterForeground:
-                state.availableVoices = speechClient.availableVoices()
-                return .none
             case .onTask:
-                return .run { send in
-                    for await _ in sceneWillEnterForeground {
-                        await send(.onSceneWillEnterForeground)
-                    }
-                }
-            case .testVoiceButtonTapped:
-                let spokenText = "1234"
-                enum CancelID { case speakAction }
-                return .run { [settings = state.speechSettings] send in
-                    await withTaskCancellation(id: CancelID.speakAction, cancelInFlight: true) {
-                        do {
-                            let utterance = SpeechSynthesisUtterance(speechString: spokenText, settings: settings)
-                            try await speechClient.speak(utterance)
-                        } catch {
-                            assertionFailure(error.localizedDescription)
-                        }
-                    }
-                }
+                return .send(.speechSettings(.onTask))
+            case .speechSettings:
+                return .none
             }
         }
     }
@@ -126,71 +68,9 @@ struct SettingsView: View {
                             .font(.subheadline)
                     }
 
-                    Section {
-                        if let $unwrappedVoiceIdentifier = Binding(viewStore.$rawVoiceIdentifier) {
-                            Picker(selection: $unwrappedVoiceIdentifier) {
-                                ForEach(viewStore.availableVoices) { voice in
-                                    Text(voice.name)
-                                        .tag(Optional(voice.voiceIdentifier))
-                                }
-                            } label: {
-                                Text("Voice name")
-                            }
-                            .pickerStyle(.navigationLink)
-                            NavigationLink {
-                                GetMoreVoicesView()
-                            } label: {
-                                Text("Get more voices")
-                            }
-                            HStack {
-                                Text("Rate")
-                                    .onTapGesture(count: 2) {
-                                        viewStore.send(.rateLabelDoubleTapped)
-                                    }
-                                Slider(value: viewStore.$rawSpeechRate, in: viewStore.speechRateRange, step: 0.05) {
-                                    Text("Speech rate")
-                                } minimumValueLabel: {
-                                    Image(systemName: "tortoise")
-                                } maximumValueLabel: {
-                                    Image(systemName: "hare")
-                                }
-                            }
-                            HStack {
-                                Text("Pitch")
-                                    .onTapGesture(count: 2) {
-                                        viewStore.send(.pitchLabelDoubleTapped)
-                                    }
-                                Slider(value: viewStore.$rawPitchMultiplier, in: viewStore.pitchMultiplierRange, step: 0.05) {
-                                    Text("Pitch")
-                                } minimumValueLabel: {
-                                    Image(systemName: "dial.low")
-                                } maximumValueLabel: {
-                                    Image(systemName: "dial.high")
-                                }
-                            }
-                            Button {
-                                viewStore.send(.testVoiceButtonTapped)
-                            } label: {
-                                HStack(spacing: 10) {
-                                    Image(systemName: "person.wave.2")
-                                    Text("Test Voice")
-                                }
-                                .frame(maxWidth: .infinity, alignment: .center)
-                            }
-                        } else {
-                            NavigationLink {
-                                GetMoreVoicesView()
-                            } label: {
-                                HStack {
-                                    Text("Error: no voices found on device")
-                                        .foregroundStyle(Color.red)
-                                }
-                            }
-                        }
-                    } header: {
-                        Text("Voice Settings")
-                            .font(.subheadline)
-                    }
+                    SpeechSettingsSection(
+                        store: store.scope(state: \.speechSettings, action: { .speechSettings($0) })
+                    )
                 }
                 .navigationBarTitleDisplayMode(.inline)
                 .navigationTitle("Session")
@@ -218,7 +98,7 @@ struct SettingsView: View {
 
 #Preview {
     SettingsView(
-        store: Store(initialState: SettingsFeature.State(topicID: Topic.mockID, speechSettings: .mock)) {
+        store: Store(initialState: SettingsFeature.State(topicID: Topic.mockID)) {
             SettingsFeature()
                 ._printChanges()
         } withDependencies: { deps in

--- a/count/Feature/SettingsFeature.swift
+++ b/count/Feature/SettingsFeature.swift
@@ -8,7 +8,6 @@ struct SettingsFeature: Reducer {
         let topic: Topic
 
         init(topicID: UUID, speechSettings: SpeechSettingsFeature.State = .init()) {
-            @Dependency(\.speechSynthesisClient) var speechClient
             @Dependency(\.topicClient.allTopics) var allTopics
 
             topic = allTopics()[id: topicID]!

--- a/count/Feature/SpeechSettingsFeature.swift
+++ b/count/Feature/SpeechSettingsFeature.swift
@@ -181,6 +181,9 @@ struct SpeechSettingsSection: View {
                 Text("Voice Settings")
                     .font(.subheadline)
             }
+            .task {
+                await viewStore.send(.onTask).finish()
+            }
         }
     }
 }

--- a/count/Feature/SpeechSettingsFeature.swift
+++ b/count/Feature/SpeechSettingsFeature.swift
@@ -1,0 +1,185 @@
+import ComposableArchitecture
+import SwiftUI
+
+struct SpeechSettingsFeature: Reducer {
+    struct State: Equatable {
+        var availableVoices: [SpeechSynthesisVoice]
+        @BindingState var rawSpeechRate: Float
+        @BindingState var rawVoiceIdentifier: String?
+        @BindingState var rawPitchMultiplier: Float
+        let pitchMultiplierRange: ClosedRange<Float>
+        let speechRateRange: ClosedRange<Float>
+        var speechSettings: SpeechSynthesisSettings
+
+        init() {
+            @Dependency(\.speechSynthesisSettingsClient) var speechSettingsClient
+            @Dependency(\.speechSynthesisClient) var speechClient
+
+            speechSettings = speechSettingsClient.get()
+
+            availableVoices = speechClient.availableVoices()
+            rawVoiceIdentifier = speechSettings.voiceIdentifier ?? speechClient.defaultVoice()?.voiceIdentifier
+
+            let speechRateAttributes = speechClient.speechRateAttributes()
+            rawSpeechRate = speechSettings.rate ?? speechRateAttributes.defaultRate
+            speechRateRange = speechRateAttributes.minimumRate ... speechRateAttributes.maximumRate
+
+            let pitchMultiplierAttributes = speechClient.pitchMultiplierAttributes()
+            rawPitchMultiplier = speechSettings.pitchMultiplier ?? pitchMultiplierAttributes.defaultPitch
+            pitchMultiplierRange = pitchMultiplierAttributes.minimumPitch ... pitchMultiplierAttributes.maximumPitch
+        }
+    }
+
+    enum Action: BindableAction, Equatable {
+        case binding(BindingAction<State>)
+        case onSceneWillEnterForeground
+        case onTask
+        case pitchLabelDoubleTapped
+        case rateLabelDoubleTapped
+        case testVoiceButtonTapped
+    }
+
+    private enum CancelID {
+        case saveDebounce
+    }
+
+    @Dependency(\.continuousClock) var clock
+    @Dependency.Notification(\.sceneWillEnterForeground) var sceneWillEnterForeground
+    @Dependency(\.speechSynthesisSettingsClient) var speechSettingsClient
+    @Dependency(\.speechSynthesisClient) var speechClient
+
+    var body: some ReducerOf<Self> {
+        BindingReducer()
+        Reduce { state, action in
+            switch action {
+            case .binding(\.$rawSpeechRate):
+                state.speechSettings.rate = state.rawSpeechRate
+                return .none
+            case .binding(\.$rawVoiceIdentifier):
+                state.speechSettings.voiceIdentifier = state.rawVoiceIdentifier
+                return .none
+            case .binding(\.$rawPitchMultiplier):
+                state.speechSettings.pitchMultiplier = state.rawPitchMultiplier
+                return .none
+            case .binding:
+                return .none
+            case .pitchLabelDoubleTapped:
+                state.rawPitchMultiplier = speechClient.pitchMultiplierAttributes().defaultPitch
+                state.speechSettings.pitchMultiplier = state.rawPitchMultiplier
+                return .none
+            case .rateLabelDoubleTapped:
+                state.rawSpeechRate = speechClient.speechRateAttributes().defaultRate
+                state.speechSettings.rate = state.rawSpeechRate
+                return .none
+            case .onSceneWillEnterForeground:
+                state.availableVoices = speechClient.availableVoices()
+                return .none
+            case .onTask:
+                return .run { send in
+                    for await _ in sceneWillEnterForeground {
+                        await send(.onSceneWillEnterForeground)
+                    }
+                }
+            case .testVoiceButtonTapped:
+                let spokenText = "1234"
+                enum CancelID { case speakAction }
+                return .run { [settings = state.speechSettings] send in
+                    await withTaskCancellation(id: CancelID.speakAction, cancelInFlight: true) {
+                        do {
+                            let utterance = SpeechSynthesisUtterance(speechString: spokenText, settings: settings)
+                            try await speechClient.speak(utterance)
+                        } catch {
+                            assertionFailure(error.localizedDescription)
+                        }
+                    }
+                }
+            }
+        }
+        .onChange(of: \.speechSettings) { _, newValue in
+            Reduce { state, _ in
+                .run { _ in
+                    try await withTaskCancellation(id: CancelID.saveDebounce, cancelInFlight: true) {
+                        try await clock.sleep(for: .seconds(0.25))
+                        try speechSettingsClient.set(newValue)
+                    }
+                } catch: { _, _ in
+                    XCTFail("SpeechSettingsClient unexpectedly failed to write")
+                }
+            }
+        }
+    }
+}
+
+struct SpeechSettingsSection: View {
+    let store: StoreOf<SpeechSettingsFeature>
+
+    var body: some View {
+        WithViewStore(store, observe: { $0 }) { viewStore in
+            Section {
+                if let $unwrappedVoiceIdentifier = Binding(viewStore.$rawVoiceIdentifier) {
+                    Picker(selection: $unwrappedVoiceIdentifier) {
+                        ForEach(viewStore.availableVoices) { voice in
+                            Text(voice.name)
+                                .tag(Optional(voice.voiceIdentifier))
+                        }
+                    } label: {
+                        Text("Voice name")
+                    }
+                    .pickerStyle(.navigationLink)
+                    NavigationLink {
+                        GetMoreVoicesView()
+                    } label: {
+                        Text("Get more voices")
+                    }
+                    HStack {
+                        Text("Rate")
+                            .onTapGesture(count: 2) {
+                                viewStore.send(.rateLabelDoubleTapped)
+                            }
+                        Slider(value: viewStore.$rawSpeechRate, in: viewStore.speechRateRange, step: 0.05) {
+                            Text("Speech rate")
+                        } minimumValueLabel: {
+                            Image(systemName: "tortoise")
+                        } maximumValueLabel: {
+                            Image(systemName: "hare")
+                        }
+                    }
+                    HStack {
+                        Text("Pitch")
+                            .onTapGesture(count: 2) {
+                                viewStore.send(.pitchLabelDoubleTapped)
+                            }
+                        Slider(value: viewStore.$rawPitchMultiplier, in: viewStore.pitchMultiplierRange, step: 0.05) {
+                            Text("Pitch")
+                        } minimumValueLabel: {
+                            Image(systemName: "dial.low")
+                        } maximumValueLabel: {
+                            Image(systemName: "dial.high")
+                        }
+                    }
+                    Button {
+                        viewStore.send(.testVoiceButtonTapped)
+                    } label: {
+                        HStack(spacing: 10) {
+                            Image(systemName: "person.wave.2")
+                            Text("Test Voice")
+                        }
+                        .frame(maxWidth: .infinity, alignment: .center)
+                    }
+                } else {
+                    NavigationLink {
+                        GetMoreVoicesView()
+                    } label: {
+                        HStack {
+                            Text("Error: no voices found on device")
+                                .foregroundStyle(Color.red)
+                        }
+                    }
+                }
+            } header: {
+                Text("Voice Settings")
+                    .font(.subheadline)
+            }
+        }
+    }
+}

--- a/count/Feature/SpeechSettingsFeature.swift
+++ b/count/Feature/SpeechSettingsFeature.swift
@@ -101,10 +101,12 @@ struct SpeechSettingsFeature: Reducer {
                 .run { _ in
                     try await withTaskCancellation(id: CancelID.saveDebounce, cancelInFlight: true) {
                         try await clock.sleep(for: .seconds(0.25))
-                        try speechSettingsClient.set(newValue)
+                        do {
+                            try await speechSettingsClient.set(newValue)
+                        } catch {
+                            XCTFail("SpeechSettingsClient unexpectedly failed to write: \(error)")
+                        }
                     }
-                } catch: { _, _ in
-                    XCTFail("SpeechSettingsClient unexpectedly failed to write")
                 }
             }
         }

--- a/count/Feature/SpeechSettingsFeature.swift
+++ b/count/Feature/SpeechSettingsFeature.swift
@@ -1,3 +1,4 @@
+import _NotificationDependency
 import ComposableArchitecture
 import SwiftUI
 


### PR DESCRIPTION
- Move duplicated `SpeechSettings` reducer/view code from `PreSettingsFeature` and `SettingsFeature` into `SpeechSettingsFeature` and `SpeechSettingsSection`.
- Move get/set/observation from inter-reducer responsibility to inner-reducer responsibility.
- Add `observe` interface to `SpeechSynthesisSettingsClient`.
- Change UserDefaults keys from dot-separated to underscore-separated due to KVO bug/issue. https://hachyderm.io/@twocentstudios/111370325045008914
