### PR TITLE
Disable quiz timer when settings is presented

### DIFF
--- a/count/Feature/ListeningQuizFeature.swift
+++ b/count/Feature/ListeningQuizFeature.swift
@@ -104,6 +104,7 @@ struct ListeningQuizFeature: Reducer {
     struct State: Equatable {
         var bikiAnimation: BikiAnimation?
         var confettiAnimation: Int = 0
+        var isViewFrontmost: Bool = true
         var isShowingPlaybackError: Bool = false
         var isSpeaking: Bool = false
         @BindingState var pendingSubmissionValue: String = ""
@@ -245,7 +246,7 @@ struct ListeningQuizFeature: Reducer {
                     })
 
             case .onTimerTick:
-                if applicationState == .active {
+                if state.isViewFrontmost && applicationState == .active {
                     state.secondsElapsed += 1
                 }
                 return .none


### PR DESCRIPTION
This PR fixes a bug where, in time limit mode, the timer would continue to count down while the settings screen was presented.

- Add `isViewFrontmost` flag to `ListeningQuizFeature.State`.
- Set `isViewFrontmost` on each `Reduce` within `ListeningQuizNavigation` based on the current navigation state.

### Discussion

It's possible to derive the state of `isViewFrontmost` instead of setting it on each change. However, I can't find an ergonomic way to derive only one field of a `struct` from a parent. I was mostly looking at the example from the [Shared State case study](https://github.com/pointfreeco/swift-composable-architecture/blob/main/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-SharedState.swift) and felt it would be cumbersome to copy all fields in a `get set` property. I could also just pass the entire `ListeningQuizNavigationFeature.State` as `ListeningQuizFeature.State`, however that feels like it blurs the lines in a weird way. Perhaps there's another way to separate the features and state and views that keeps the cleanish organization I have while still allowing me to pass a single derived property between parent and child.

For now, this feels like the least disruptive way to pass the `isViewFrontmost` information from parent to child.

It technically not required to tell the quiz view that `Path` is full because the `task` that triggers the timer will be cancelled. However, I'm doing it just for API purity and completeness in case `isViewFrontmost` is used in a different context later.