### PR TITLE
Add display settings

### DIFF
--- a/Dependencies/SessionSettings.swift
+++ b/Dependencies/SessionSettings.swift
@@ -30,11 +30,10 @@ struct SessionSettings: Equatable, Codable {
     var showProgress: Bool
     var showBiki: Bool
     var showConfetti: Bool
-    var playHaptics: Bool
 }
 
 extension SessionSettings {
-    static let `default`: Self = .init(quizMode: .infinite, questionLimit: 10, timeLimit: 60, showProgress: true, showBiki: true, showConfetti: true, playHaptics: true)
+    static let `default`: Self = .init(quizMode: .infinite, questionLimit: 10, timeLimit: 60, showProgress: true, showBiki: true, showConfetti: true)
 
     static let questionLimitValues: [Int] = [5, 10, 20, 30, 50, 100]
     static let timeLimitValues: [Int] = [30, 1 * 60, 3 * 60, 5 * 60, 10 * 60, 20 * 60]

--- a/Dependencies/SessionSettings.swift
+++ b/Dependencies/SessionSettings.swift
@@ -27,13 +27,13 @@ struct SessionSettings: Equatable, Codable {
     var questionLimit: Int
     var timeLimit: Int // seconds
 
-    var showProgress: Bool
-    var showBiki: Bool
-    var showConfetti: Bool
+    var isShowingProgress: Bool
+    var isShowingBiki: Bool
+    var isShowingConfetti: Bool
 }
 
 extension SessionSettings {
-    static let `default`: Self = .init(quizMode: .infinite, questionLimit: 10, timeLimit: 60, showProgress: true, showBiki: true, showConfetti: true)
+    static let `default`: Self = .init(quizMode: .infinite, questionLimit: 10, timeLimit: 60, isShowingProgress: true, isShowingBiki: true, isShowingConfetti: true)
 
     static let questionLimitValues: [Int] = [5, 10, 20, 30, 50, 100]
     static let timeLimitValues: [Int] = [30, 1 * 60, 3 * 60, 5 * 60, 10 * 60, 20 * 60]

--- a/count/Feature/ListeningQuizFeature.swift
+++ b/count/Feature/ListeningQuizFeature.swift
@@ -190,7 +190,9 @@ struct ListeningQuizFeature: Reducer {
                     state.completedChallenges.append(state.challenge)
                     state.pendingSubmissionValue = ""
                     state.bikiAnimation = .init(id: uuid(), kind: .correct)
-                    state.confettiAnimation += 1
+                    if state.sessionSettings.showConfetti {
+                        state.confettiAnimation += 1
+                    }
                     if state.isSessionComplete {
                         return playSuccessHaptics(state: state)
                     } else {

--- a/count/Feature/ListeningQuizFeature.swift
+++ b/count/Feature/ListeningQuizFeature.swift
@@ -263,7 +263,7 @@ struct ListeningQuizFeature: Reducer {
                     })
 
             case .onTimerTick:
-                if state.isViewFrontmost && applicationState == .active {
+                if state.isViewFrontmost, applicationState == .active {
                     state.secondsElapsed += 1
                 }
                 return .none
@@ -287,7 +287,7 @@ struct ListeningQuizFeature: Reducer {
         }
     }
 
-    func generateChallenge(state: inout State) {
+    private func generateChallenge(state: inout State) {
         let question = try! topicClient.generateQuestion(state.topicID) // TODO: handle error
         let challenge = Challenge(id: uuid(), startDate: now, question: question, submissions: [])
         state.challenge = challenge

--- a/count/Feature/ListeningQuizFeature.swift
+++ b/count/Feature/ListeningQuizFeature.swift
@@ -190,7 +190,7 @@ struct ListeningQuizFeature: Reducer {
                     state.completedChallenges.append(state.challenge)
                     state.pendingSubmissionValue = ""
                     state.bikiAnimation = .init(id: uuid(), kind: .correct)
-                    if state.sessionSettings.showConfetti {
+                    if state.sessionSettings.isShowingConfetti {
                         state.confettiAnimation += 1
                     }
                     if state.isSessionComplete {
@@ -390,7 +390,7 @@ struct ListeningQuizView: View {
 
                 Spacer()
 
-                if viewStore.sessionSettings.showProgress {
+                if viewStore.sessionSettings.isShowingProgress {
                     progressBar(viewStore: viewStore)
                 }
             }
@@ -489,7 +489,7 @@ struct ListeningQuizView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
 
-            if viewStore.sessionSettings.showBiki {
+            if viewStore.sessionSettings.isShowingBiki {
                 CountBikiView(bikiAnimation: viewStore.bikiAnimation)
                     .aspectRatio(contentMode: .fit)
                     .frame(maxWidth: 90)

--- a/count/Feature/ListeningQuizFeature.swift
+++ b/count/Feature/ListeningQuizFeature.swift
@@ -388,7 +388,9 @@ struct ListeningQuizView: View {
 
                 Spacer()
 
-                progressBar(viewStore: viewStore)
+                if viewStore.sessionSettings.showProgress {
+                    progressBar(viewStore: viewStore)
+                }
             }
             .padding(.top, 16)
             .padding(.bottom, 6)

--- a/count/Feature/ListeningQuizFeature.swift
+++ b/count/Feature/ListeningQuizFeature.swift
@@ -487,9 +487,11 @@ struct ListeningQuizView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
 
-            CountBikiView(bikiAnimation: viewStore.bikiAnimation)
-                .aspectRatio(contentMode: .fit)
-                .frame(maxWidth: 90)
+            if viewStore.sessionSettings.showBiki {
+                CountBikiView(bikiAnimation: viewStore.bikiAnimation)
+                    .aspectRatio(contentMode: .fit)
+                    .frame(maxWidth: 90)
+            }
         }
         .frame(maxWidth: .infinity)
     }

--- a/count/Feature/PreSettingsFeature.swift
+++ b/count/Feature/PreSettingsFeature.swift
@@ -25,7 +25,7 @@ struct PreSettingsFeature: Reducer {
     }
 
     @Dependency(\.speechSynthesisClient) var speechClient
-    @Dependency(\.sessionSettingsClient) var sessionSettingsClient
+    @Dependency(\.sessionSettingsClient.set) var setSessionSettings
 
     var body: some ReducerOf<Self> {
         BindingReducer()
@@ -46,12 +46,13 @@ struct PreSettingsFeature: Reducer {
         }
         .onChange(of: \.sessionSettings) { _, newValue in
             Reduce { _, _ in
-                do {
-                    try sessionSettingsClient.set(newValue)
-                } catch {
-                    XCTFail("SessionSettingsClient unexpectedly failed to write")
+                .run { _ in
+                    do {
+                        try await setSessionSettings(newValue)
+                    } catch {
+                        XCTFail("SessionSettingsClient unexpectedly failed to write")
+                    }
                 }
-                return .none
             }
         }
     }

--- a/count/Feature/SettingsFeature.swift
+++ b/count/Feature/SettingsFeature.swift
@@ -84,13 +84,13 @@ struct SettingsView: View {
                     }
 
                     Section {
-                        Toggle(isOn: viewStore.$sessionSettings.showProgress, label: {
+                        Toggle(isOn: viewStore.$sessionSettings.isShowingProgress, label: {
                             Text("Show progress")
                         })
-                        Toggle(isOn: viewStore.$sessionSettings.showBiki, label: {
+                        Toggle(isOn: viewStore.$sessionSettings.isShowingBiki, label: {
                             Text("Show Biki")
                         })
-                        Toggle(isOn: viewStore.$sessionSettings.showConfetti, label: {
+                        Toggle(isOn: viewStore.$sessionSettings.isShowingConfetti, label: {
                             Text("Show confetti")
                         })
                     } header: {

--- a/count/Feature/SettingsFeature.swift
+++ b/count/Feature/SettingsFeature.swift
@@ -29,14 +29,16 @@ struct SettingsFeature: Reducer {
     @Dependency(\.sessionSettingsClient.set) var setSessionSettings
 
     var body: some ReducerOf<Self> {
-        BindingReducer()
-        Reduce { state, action in
-            switch action {
-            case .binding:
-                return .none
-            case .doneButtonTapped:
-                return .run { send in
-                    await dismiss()
+        CombineReducers {
+            BindingReducer()
+            Reduce { state, action in
+                switch action {
+                case .binding:
+                    return .none
+                case .doneButtonTapped:
+                    return .run { send in
+                        await dismiss()
+                    }
                 }
             }
         }

--- a/count/Feature/SettingsFeature.swift
+++ b/count/Feature/SettingsFeature.swift
@@ -93,9 +93,6 @@ struct SettingsView: View {
                         Toggle(isOn: viewStore.$sessionSettings.showConfetti, label: {
                             Text("Show confetti")
                         })
-                        Toggle(isOn: viewStore.$sessionSettings.playHaptics, label: {
-                            Text("Play haptic feedback")
-                        })
                     } header: {
                         Text("Display Settings")
                             .font(.subheadline)

--- a/count/Feature/SettingsFeature.swift
+++ b/count/Feature/SettingsFeature.swift
@@ -3,27 +3,54 @@ import SwiftUI
 
 struct SettingsFeature: Reducer {
     struct State: Equatable {
+        @BindingState var sessionSettings: SessionSettings
         let topic: Topic
 
         init(topicID: UUID) {
             @Dependency(\.topicClient.allTopics) var allTopics
+            @Dependency(\.sessionSettingsClient) var sessionSettingsClient
 
             topic = allTopics()[id: topicID]!
+            sessionSettings = sessionSettingsClient.get()
         }
     }
 
-    enum Action: Equatable {
+    enum Action: BindableAction, Equatable {
+        case binding(BindingAction<State>)
         case doneButtonTapped
     }
 
+    private enum CancelID {
+        case saveDebounce
+    }
+
+    @Dependency(\.continuousClock) var clock
     @Dependency(\.dismiss) var dismiss
+    @Dependency(\.sessionSettingsClient.set) var setSessionSettings
 
     var body: some ReducerOf<Self> {
+        BindingReducer()
         Reduce { state, action in
             switch action {
+            case .binding:
+                return .none
             case .doneButtonTapped:
                 return .run { send in
                     await dismiss()
+                }
+            }
+        }
+        .onChange(of: \.sessionSettings) { _, newValue in
+            Reduce { state, _ in
+                .run { _ in
+                    try await withTaskCancellation(id: CancelID.saveDebounce, cancelInFlight: true) {
+                        try await clock.sleep(for: .seconds(0.25))
+                        do {
+                            try await setSessionSettings(newValue)
+                        } catch {
+                            XCTFail("SpeechSettingsClient unexpectedly failed to write: \(error)")
+                        }
+                    }
                 }
             }
         }
@@ -51,6 +78,24 @@ struct SettingsView: View {
                         .padding(.vertical, 2)
                     } header: {
                         Text("Topic")
+                            .font(.subheadline)
+                    }
+
+                    Section {
+                        Toggle(isOn: viewStore.$sessionSettings.showProgress, label: {
+                            Text("Show progress")
+                        })
+                        Toggle(isOn: viewStore.$sessionSettings.showBiki, label: {
+                            Text("Show Biki")
+                        })
+                        Toggle(isOn: viewStore.$sessionSettings.showConfetti, label: {
+                            Text("Show confetti")
+                        })
+                        Toggle(isOn: viewStore.$sessionSettings.playHaptics, label: {
+                            Text("Play haptic feedback")
+                        })
+                    } header: {
+                        Text("Display Settings")
                             .font(.subheadline)
                     }
 


### PR DESCRIPTION
Add 3 display settings to the in-session settings screen:

- show/hide progress
- show/hide biki
- show confetti

No user has specifically asked for these, but since I've already set the foundation for persisted settings, I figured I'd add them, especially for accessibility purposes.

I also had a setting for playing haptics, but this is actually controllable from iOS accessibility settings, so I think it's unnecessary. If a user asks for it in the future it's not too hard to add.

## Implementation Details

- Add `SessionSettingsClient.observe`.
- Add Display Settings section to in-session settings screen (get/set).
- get/observe session settings in quiz.
- check session setting value before showing relevant view or updating confetti integer.

## Screenshots

Display settings disabled|Settings screen
-|-
![Simulator Screenshot - iPhone 15 Pro - 2023-11-13 at 21 05 12](https://github.com/twocentstudios/count-biki/assets/603478/834c46a0-0768-47d4-96d3-33cef2e87bae)|![Simulator Screenshot - iPhone 15 Pro - 2023-11-13 at 21 05 06](https://github.com/twocentstudios/count-biki/assets/603478/a5b8441c-7066-441b-82cc-7abe451a98c6)
