### PR TITLE
Fix last topic obscured by session settings sheet

### DIFF
--- a/count/Feature/TopicsFeature.swift
+++ b/count/Feature/TopicsFeature.swift
@@ -149,6 +149,10 @@ struct TopicsView: View {
                                         }
                                     }
                                 }
+                                .safeAreaInset(edge: .bottom) {
+                                    // extra bottom padding for session settings sheet
+                                    Spacer().frame(height: 100)
+                                }
                                 .navigationBarTitleDisplayMode(.inline)
                                 .navigationTitle(category.title)
                                 .toolbar {


### PR DESCRIPTION
The last topic in the Date & Times category was obscured by the session settings sheet. The whole list needs some extra safe area padding to account for that sheet not being dismissable.

Note we use `safeAreaInset` instead of `safeAreaPadding` because the latter is iOS 17 only.

## Screenshots

Before|After
-|-
![Simulator Screenshot - iPhone 15 Pro - 2023-11-22 at 00 16 21](https://github.com/twocentstudios/count-biki/assets/603478/dc383b48-7f42-42a6-934d-abc3da266db3)|![Simulator Screenshot - iPhone 15 Pro - 2023-11-22 at 00 16 00](https://github.com/twocentstudios/count-biki/assets/603478/76b8c83b-184f-40f3-9d9c-0664b089207c)

