### PR TITLE
Bump minimum build target to iOS 17; Bump TCA to 1.9

### DIFF
--- a/Dependencies/SpeechSynthesis.swift
+++ b/Dependencies/SpeechSynthesis.swift
@@ -1,4 +1,4 @@
-@preconcurrency import AVFoundation
+import AVFoundation
 import Dependencies
 
 struct SpeechSynthesisClient {

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img width="250" src="/count/Assets.xcassets/AppIcon.appiconset/icon05.png">
 
-Count Biki is an iOS app for drilling Japanese numbers and more. It supports iOS 16.4+.
+Count Biki is an iOS app for drilling Japanese numbers and more. It supports iOS 17.0+.
 
 ### [Download from the App Store](https://apps.apple.com/us/app/count-biki/id6463796779)
 

--- a/count.xcodeproj/project.pbxproj
+++ b/count.xcodeproj/project.pbxproj
@@ -707,7 +707,7 @@
 			repositoryURL = "https://github.com/apple/swift-collections.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.4;
+				minimumVersion = 1.1.0;
 			};
 		};
 		344242382ACA98CA001E2FC8 /* XCRemoteSwiftPackageReference "AsyncExtensions" */ = {

--- a/count.xcodeproj/project.pbxproj
+++ b/count.xcodeproj/project.pbxproj
@@ -296,7 +296,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1430;
-				LastUpgradeCheck = 1500;
+				LastUpgradeCheck = 1530;
 				TargetAttributes = {
 					340A51C82A78EC78007DCA0C = {
 						CreatedOnToolsVersion = 14.3.1;
@@ -414,6 +414,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -474,6 +475,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -551,7 +553,7 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 13.3;
@@ -596,7 +598,7 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 13.3;

--- a/count.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/count.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "5da6989aae464f324eef5c5b52bdb7974725ab81",
-        "version" : "1.0.0"
+        "revision" : "e593aba2c6222daad7c4f2732a431eed2c09bb07",
+        "version" : "1.3.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
-        "revision" : "d1fd837326aa719bee979bdde1f53cd5797443eb",
-        "version" : "1.0.0"
+        "revision" : "a8421d68068d8f45fbceb418fbf22c5dad4afd33",
+        "version" : "1.0.2"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture.git",
       "state" : {
-        "revision" : "9b0f600253f467f61cbd53f60ccc243cc4ff27cd",
-        "version" : "1.3.0"
+        "revision" : "115fe5af41d333b6156d4924d7c7058bc77fd580",
+        "version" : "1.9.2"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
       "state" : {
-        "revision" : "6155400cb15b0d99b2c257d57603d61d03a817a8",
-        "version" : "1.0.1"
+        "revision" : "bb5059bde9022d69ac516803f4f227d8ac967f71",
+        "version" : "1.1.0"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "65fc9e2b62727cacfab9fc60d580c284a4b9308c",
-        "version" : "1.1.1"
+        "revision" : "f01efb26f3a192a0e88dcdb7c3c391ec2fc25d9c",
+        "version" : "1.3.0"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "4e1eb6e28afe723286d8cc60611237ffbddba7c5",
-        "version" : "1.0.0"
+        "revision" : "d3a5af3038a09add4d7682f66555d6212058a3c0",
+        "version" : "1.2.2"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tgrapperon/swift-dependencies-additions",
       "state" : {
-        "revision" : "3223855b5ad1e049bc89330496a09ff7a69c5a48",
-        "version" : "1.0.0"
+        "revision" : "02e7b1801a96828049fe4d3e8bdc5e608ef5ffbc",
+        "version" : "1.0.1"
       }
     },
     {
@@ -110,12 +110,30 @@
       }
     },
     {
+      "identity" : "swift-perception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-perception",
+      "state" : {
+        "revision" : "83fc3d89676b33f1c3d49e9268e76ef62430339f",
+        "version" : "1.1.3"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax",
+      "state" : {
+        "revision" : "fa8f95c2d536d6620cc2f504ebe8a6167c9fc2dd",
+        "version" : "510.0.1"
+      }
+    },
+    {
       "identity" : "swiftui-navigation",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swiftui-navigation",
       "state" : {
-        "revision" : "74adfb8e48724c50d0ac148c658ae5fa7dfd6b6d",
-        "version" : "1.0.3"
+        "revision" : "d9e72f3083c08375794afa216fb2f89c0114f303",
+        "version" : "1.2.1"
       }
     },
     {
@@ -123,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "23cbf2294e350076ea4dbd7d5d047c1e76b03631",
-        "version" : "1.0.2"
+        "revision" : "b13b1d1a8e787a5ffc71ac19dcaf52183ab27ba2",
+        "version" : "1.1.1"
       }
     }
   ],

--- a/count.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/count.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "2ccb8cd7ee27cd6778e6cca89a519a45bca79d748124e69bc0b318f3c9470019",
   "pins" : [
     {
       "identity" : "asyncextensions",
@@ -50,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "a902f1823a7ff3c9ab2fba0f992396b948eda307",
-        "version" : "1.0.5"
+        "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
+        "version" : "1.1.0"
       }
     },
     {
@@ -127,5 +128,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/count/Feature/AboutFeature.swift
+++ b/count/Feature/AboutFeature.swift
@@ -3,7 +3,7 @@ import StoreKit
 import SwiftUI
 
 @Reducer struct AboutFeature {
-    struct State: Equatable, Sendable {
+    @ObservableState struct State: Equatable, Sendable {
         var appIcon: AppIconFeature.State
         var transylvaniaTier: TransylvaniaTierFeature.State
 
@@ -60,145 +60,143 @@ struct AboutView: View {
     @Environment(\.requestReview) var requestReview
 
     var body: some View {
-        WithViewStore(store, observe: { $0 }) { viewStore in
-            NavigationStack {
-                List {
-                    Section {
-                        VStack(spacing: 0) {
-                            CountBikiView()
-                                .frame(width: 100, height: 100)
-                            Text("Count Biki")
-                                .font(.largeTitle)
-                                .bold()
-                            Text("Master Japanese numbers")
-                                .font(.subheadline)
-                                .foregroundStyle(.secondary)
-                                .fontDesign(.default)
-                                .italic()
-                        }
-                        .frame(maxWidth: .infinity)
+        NavigationStack {
+            List {
+                Section {
+                    VStack(spacing: 0) {
+                        CountBikiView()
+                            .frame(width: 100, height: 100)
+                        Text("Count Biki")
+                            .font(.largeTitle)
+                            .bold()
+                        Text("Master Japanese numbers")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .fontDesign(.default)
+                            .italic()
                     }
-
-                    Section {
-                        NavigationLink {
-                            TranslyvaniaTierView(store: store.scope(state: \.transylvaniaTier, action: \.transylvaniaTier))
-                        } label: {
-                            Label("Leave a tip", systemImage: "yensign.circle")
-                        }
-                        NavigationLink {
-                            AppIconView(store: store.scope(state: \.appIcon, action: \.appIcon))
-                        } label: {
-                            Label("Choose app icon", systemImage: viewStore.transylvaniaTier.hasTranslyvaniaTier ? "app.badge" : "lock")
-                        }
-                        if false { // TODO: choose Biki's outfit
-                            Label("Choose Biki's outfit", systemImage: "tshirt")
-                        }
-                    } header: {
-                        Text("Transylvania Tier")
-                    } footer: {
-                        if viewStore.transylvaniaTier.hasTranslyvaniaTier {
-                            Text("You've unlocked Translyvania Tier. Thanks for your support!")
-                        } else {
-                            Text("Leave any size tip to join Transylvania Tier. Unlock whimsical benefits and support the app's development.")
-                        }
-                    }
-
-                    Section {
-                        Link(destination: MailTo.reportBug) {
-                            Label("Report a bug", systemImage: "ladybug")
-                        }
-                        Link(destination: MailTo.reportContentError) {
-                            Label("Report a content error", systemImage: "exclamationmark.bubble")
-                        }
-                        Link(destination: MailTo.suggestTopic) {
-                            Label("Suggest a new Topic", systemImage: "lightbulb")
-                        }
-                        Link(destination: MailTo.sendNiceMessage) {
-                            Label("Send the developer a nice message", systemImage: "face.smiling")
-                        }
-                        Button {
-                            requestReview()
-                        } label: {
-                            Label("Rate on the App Store", systemImage: "star")
-                        }
-                        Link(destination: URL(string: "https://apps.apple.com/app/id\(appStoreAppID)?action=write-review")!) {
-                            Label("Review on the App Store", systemImage: "square.and.pencil")
-                        }
-                    } header: {
-                        Text("Support")
-                    }
-                    .tint(Color(.label))
-
-                    Section {
-                        VStack {
-                            Image("ct_avatar_about")
-                                .resizable()
-                                .clipShape(Circle())
-                                .padding(2)
-                                .background { Circle().fill(Color(.systemBackground), stroke: Color(.secondarySystemBackground)) }
-                                .aspectRatio(contentMode: .fit)
-                                .frame(width: 100, height: 100)
-                                .frame(maxWidth: .infinity, alignment: .center)
-                            Text("Hi, I'm Chris.")
-                                .font(.title3)
-                                .bold()
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                            Text("My independent development shop is called twocentstudios. I hope you enjoy the app.")
-                                .font(.subheadline)
-                                .foregroundStyle(.secondary)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-                        .frame(maxWidth: .infinity)
-                        .listRowSeparator(.hidden)
-                        Link(destination: URL(string: "https://twocentstudios.com")!) {
-                            Label("twocentstudios.com", systemImage: "globe")
-                        }
-                        Link(destination: URL(string: "https://hachyderm.io/@twocentstudios")!) {
-                            Label("Mastodon", systemImage: "globe")
-                        }
-                        Link(destination: URL(string: "https://twitter.com/twocentstudios")!) {
-                            Label("Twitter", systemImage: "globe")
-                        }
-                    } header: {
-                        Text("About")
-                    }
-                    .tint(Color(.label))
-
-                    Section {
-                        NavigationLink {
-                            ScrollView {
-                                Text(acknowledgements()).padding()
-                            }
-                            .navigationTitle("Licenses")
-                        } label: {
-                            Label("Licenses", systemImage: "note.text")
-                        }
-                        Link(destination: GlobalURL.privacyPolicy) {
-                            Label("Privacy policy", systemImage: "note.text")
-                        }
-                    } header: {
-                        Text("Legal")
-                    }
-                    .tint(Color(.label))
+                    .frame(maxWidth: .infinity)
                 }
-                .listStyle(.insetGrouped)
-                .navigationBarTitleDisplayMode(.inline)
-                .navigationTitle("About")
-                .toolbar {
-                    ToolbarItem(placement: .principal) { Text("") }
-                    ToolbarItem(placement: .primaryAction) {
-                        Button {
-                            viewStore.send(.doneButtonTapped)
-                        } label: {
-                            Label("Done", systemImage: "xmark.circle")
-                                .labelStyle(.iconOnly)
-                        }
+
+                Section {
+                    NavigationLink {
+                        TranslyvaniaTierView(store: store.scope(state: \.transylvaniaTier, action: \.transylvaniaTier))
+                    } label: {
+                        Label("Leave a tip", systemImage: "yensign.circle")
+                    }
+                    NavigationLink {
+                        AppIconView(store: store.scope(state: \.appIcon, action: \.appIcon))
+                    } label: {
+                        Label("Choose app icon", systemImage: store.transylvaniaTier.hasTranslyvaniaTier ? "app.badge" : "lock")
+                    }
+                    if false { // TODO: choose Biki's outfit
+                        Label("Choose Biki's outfit", systemImage: "tshirt")
+                    }
+                } header: {
+                    Text("Transylvania Tier")
+                } footer: {
+                    if store.transylvaniaTier.hasTranslyvaniaTier {
+                        Text("You've unlocked Translyvania Tier. Thanks for your support!")
+                    } else {
+                        Text("Leave any size tip to join Transylvania Tier. Unlock whimsical benefits and support the app's development.")
                     }
                 }
-                .toolbarBackground(.hidden, for: .navigationBar)
-                .task {
-                    viewStore.send(.onTask)
+
+                Section {
+                    Link(destination: MailTo.reportBug) {
+                        Label("Report a bug", systemImage: "ladybug")
+                    }
+                    Link(destination: MailTo.reportContentError) {
+                        Label("Report a content error", systemImage: "exclamationmark.bubble")
+                    }
+                    Link(destination: MailTo.suggestTopic) {
+                        Label("Suggest a new Topic", systemImage: "lightbulb")
+                    }
+                    Link(destination: MailTo.sendNiceMessage) {
+                        Label("Send the developer a nice message", systemImage: "face.smiling")
+                    }
+                    Button {
+                        requestReview()
+                    } label: {
+                        Label("Rate on the App Store", systemImage: "star")
+                    }
+                    Link(destination: URL(string: "https://apps.apple.com/app/id\(appStoreAppID)?action=write-review")!) {
+                        Label("Review on the App Store", systemImage: "square.and.pencil")
+                    }
+                } header: {
+                    Text("Support")
                 }
+                .tint(Color(.label))
+
+                Section {
+                    VStack {
+                        Image("ct_avatar_about")
+                            .resizable()
+                            .clipShape(Circle())
+                            .padding(2)
+                            .background { Circle().fill(Color(.systemBackground), stroke: Color(.secondarySystemBackground)) }
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 100, height: 100)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                        Text("Hi, I'm Chris.")
+                            .font(.title3)
+                            .bold()
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        Text("My independent development shop is called twocentstudios. I hope you enjoy the app.")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .listRowSeparator(.hidden)
+                    Link(destination: URL(string: "https://twocentstudios.com")!) {
+                        Label("twocentstudios.com", systemImage: "globe")
+                    }
+                    Link(destination: URL(string: "https://hachyderm.io/@twocentstudios")!) {
+                        Label("Mastodon", systemImage: "globe")
+                    }
+                    Link(destination: URL(string: "https://twitter.com/twocentstudios")!) {
+                        Label("Twitter", systemImage: "globe")
+                    }
+                } header: {
+                    Text("About")
+                }
+                .tint(Color(.label))
+
+                Section {
+                    NavigationLink {
+                        ScrollView {
+                            Text(acknowledgements()).padding()
+                        }
+                        .navigationTitle("Licenses")
+                    } label: {
+                        Label("Licenses", systemImage: "note.text")
+                    }
+                    Link(destination: GlobalURL.privacyPolicy) {
+                        Label("Privacy policy", systemImage: "note.text")
+                    }
+                } header: {
+                    Text("Legal")
+                }
+                .tint(Color(.label))
+            }
+            .listStyle(.insetGrouped)
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationTitle("About")
+            .toolbar {
+                ToolbarItem(placement: .principal) { Text("") }
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        store.send(.doneButtonTapped)
+                    } label: {
+                        Label("Done", systemImage: "xmark.circle")
+                            .labelStyle(.iconOnly)
+                    }
+                }
+            }
+            .toolbarBackground(.hidden, for: .navigationBar)
+            .task {
+                store.send(.onTask)
             }
         }
     }

--- a/count/Feature/AboutFeature.swift
+++ b/count/Feature/AboutFeature.swift
@@ -26,10 +26,10 @@ import SwiftUI
     @Dependency(\.tierProductsClient.purchaseHistoryStream) var purchaseHistoryStream
 
     var body: some ReducerOf<Self> {
-        Scope(state: \.appIcon, action: /Action.appIcon) {
+        Scope(state: \.appIcon, action: \.appIcon) {
             AppIconFeature()
         }
-        Scope(state: \.transylvaniaTier, action: /Action.transylvaniaTier) {
+        Scope(state: \.transylvaniaTier, action: \.transylvaniaTier) {
             TransylvaniaTierFeature()
         }
         Reduce { state, action in
@@ -81,12 +81,12 @@ struct AboutView: View {
 
                     Section {
                         NavigationLink {
-                            TranslyvaniaTierView(store: store.scope(state: \.transylvaniaTier, action: { .transylvaniaTier($0) }))
+                            TranslyvaniaTierView(store: store.scope(state: \.transylvaniaTier, action: \.transylvaniaTier))
                         } label: {
                             Label("Leave a tip", systemImage: "yensign.circle")
                         }
                         NavigationLink {
-                            AppIconView(store: store.scope(state: \.appIcon, action: { .appIcon($0) }))
+                            AppIconView(store: store.scope(state: \.appIcon, action: \.appIcon))
                         } label: {
                             Label("Choose app icon", systemImage: viewStore.transylvaniaTier.hasTranslyvaniaTier ? "app.badge" : "lock")
                         }

--- a/count/Feature/AboutFeature.swift
+++ b/count/Feature/AboutFeature.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 import StoreKit
 import SwiftUI
 
-struct AboutFeature: Reducer {
+@Reducer struct AboutFeature {
     struct State: Equatable, Sendable {
         var appIcon: AppIconFeature.State
         var transylvaniaTier: TransylvaniaTierFeature.State

--- a/count/Feature/AppIconFeature.swift
+++ b/count/Feature/AppIconFeature.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 import IdentifiedCollections
 import SwiftUI
 
-struct AppIconFeature: Reducer {
+@Reducer struct AppIconFeature {
     struct State: Equatable {
         let appIcons: IdentifiedArrayOf<AppIcon>
         var selectedAppIcon: AppIcon?

--- a/count/Feature/AppIconFeature.swift
+++ b/count/Feature/AppIconFeature.swift
@@ -3,7 +3,7 @@ import IdentifiedCollections
 import SwiftUI
 
 @Reducer struct AppIconFeature {
-    struct State: Equatable {
+    @ObservableState struct State: Equatable {
         let appIcons: IdentifiedArrayOf<AppIcon>
         var selectedAppIcon: AppIcon?
         var isAppIconChangingAvailable: Bool
@@ -57,52 +57,50 @@ struct AppIconView: View {
     let store: StoreOf<AppIconFeature>
 
     var body: some View {
-        WithViewStore(store, observe: { $0 }) { viewStore in
-            ScrollView {
-                VStack(spacing: 6) {
-                    if viewStore.isAppIconChangingAvailable {
-                        Text("You've unlocked Transylvania Tier 🥳")
-                            .font(.headline)
-                        Text("Select any app icon below")
-                            .font(.subheadline)
-                    } else {
-                        Text("Unlock Transylvania Tier to change the app icon")
-                    }
+        ScrollView {
+            VStack(spacing: 6) {
+                if store.isAppIconChangingAvailable {
+                    Text("You've unlocked Transylvania Tier 🥳")
+                        .font(.headline)
+                    Text("Select any app icon below")
+                        .font(.subheadline)
+                } else {
+                    Text("Unlock Transylvania Tier to change the app icon")
                 }
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 20)
-                .padding(.vertical, 20)
-                LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 10, alignment: .center), count: 3)) {
-                    ForEach(viewStore.appIcons) { appIcon in
-                        Button {
-                            viewStore.send(.appIconTapped(appIcon))
-                        }
-                        label: {
-                            Image(uiImage: UIImage(named: appIcon.iconName) ?? UIImage())
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                                .clipShape(RoundedRectangle(cornerRadius: 20))
-                                .padding(6)
-                                .shadow(color: Color.black.opacity(0.3), radius: 6)
-                                .background {
-                                    if viewStore.selectedAppIcon == appIcon {
-                                        RoundedRectangle(cornerRadius: 26).strokeBorder(Color.accentColor, lineWidth: 6)
-                                            .transition(.scale(scale: 0.92).combined(with: .opacity))
-                                    }
+            }
+            .multilineTextAlignment(.center)
+            .padding(.horizontal, 20)
+            .padding(.vertical, 20)
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 10, alignment: .center), count: 3)) {
+                ForEach(store.appIcons) { appIcon in
+                    Button {
+                        store.send(.appIconTapped(appIcon))
+                    }
+                    label: {
+                        Image(uiImage: UIImage(named: appIcon.iconName) ?? UIImage())
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .clipShape(RoundedRectangle(cornerRadius: 20))
+                            .padding(6)
+                            .shadow(color: Color.black.opacity(0.3), radius: 6)
+                            .background {
+                                if store.selectedAppIcon == appIcon {
+                                    RoundedRectangle(cornerRadius: 26).strokeBorder(Color.accentColor, lineWidth: 6)
+                                        .transition(.scale(scale: 0.92).combined(with: .opacity))
                                 }
-                                .animation(.smooth(duration: 0.5), value: viewStore.selectedAppIcon)
-                        }
-                        .buttonStyle(.plain)
-                        .disabled(!viewStore.isAppIconChangingAvailable)
+                            }
+                            .animation(.smooth(duration: 0.5), value: store.selectedAppIcon)
                     }
+                    .buttonStyle(.plain)
+                    .disabled(!store.isAppIconChangingAvailable)
                 }
-                .padding()
             }
-            .background { Color(.secondarySystemBackground).ignoresSafeArea() }
-            .navigationTitle("App Icon")
-            .task {
-                viewStore.send(.onTask)
-            }
+            .padding()
+        }
+        .background { Color(.secondarySystemBackground).ignoresSafeArea() }
+        .navigationTitle("App Icon")
+        .task {
+            store.send(.onTask)
         }
     }
 }

--- a/count/Feature/ListeningQuizNavigationFeature.swift
+++ b/count/Feature/ListeningQuizNavigationFeature.swift
@@ -1,7 +1,7 @@
 import ComposableArchitecture
 import SwiftUI
 
-struct ListeningQuizNavigationFeature: Reducer {
+@Reducer struct ListeningQuizNavigationFeature {
     struct State: Equatable {
         var listeningQuiz: ListeningQuizFeature.State
         var path = StackState<Path.State>()

--- a/count/Feature/ListeningQuizNavigationFeature.swift
+++ b/count/Feature/ListeningQuizNavigationFeature.swift
@@ -88,10 +88,10 @@ import SwiftUI
                 return .none
             }
         }
-        .ifLet(\.$settings, action: /Action.settings) {
+        .ifLet(\.$settings, action: \.settings) {
             SettingsFeature()
         }
-        .forEach(\.path, action: /Action.path) {
+        .forEach(\.path, action: \.path) {
             Path()
         }
         Reduce { state, action in

--- a/count/Feature/ListeningQuizNavigationFeature.swift
+++ b/count/Feature/ListeningQuizNavigationFeature.swift
@@ -100,7 +100,7 @@ struct ListeningQuizNavigationView: View {
                 SessionSummaryView(store: store)
             }
         }
-        .sheet(store: store.scope(state: \.$settings, action: \.settings)) { store in
+        .sheet(item: $store.scope(state: \.settings, action: \.settings)) { store in
             SettingsView(store: store)
         }
     }

--- a/count/Feature/ListeningQuizNavigationFeature.swift
+++ b/count/Feature/ListeningQuizNavigationFeature.swift
@@ -21,7 +21,7 @@ import SwiftUI
         case settings(PresentationAction<SettingsFeature.Action>)
     }
 
-    struct Path: Reducer {
+    @Reducer struct Path {
         enum State: Equatable {
             case summary(SessionSummaryFeature.State)
         }
@@ -31,7 +31,7 @@ import SwiftUI
         }
 
         var body: some ReducerOf<Self> {
-            Scope(state: /State.summary, action: /Action.summary) {
+            Scope(state: \.summary, action: \.summary) {
                 SessionSummaryFeature()
             }
         }
@@ -40,7 +40,7 @@ import SwiftUI
     @Dependency(\.dismiss) var dismiss
 
     var body: some ReducerOf<Self> {
-        Scope(state: \.listeningQuiz, action: /Action.listeningQuiz) {
+        Scope(state: \.listeningQuiz, action: \.listeningQuiz) {
             ListeningQuizFeature()
         }
         Reduce { state, action in
@@ -105,8 +105,8 @@ struct ListeningQuizNavigationView: View {
     let store: StoreOf<ListeningQuizNavigationFeature>
 
     var body: some View {
-        NavigationStackStore(store.scope(state: \.path, action: { .path($0) })) {
-            ListeningQuizView(store: store.scope(state: \.listeningQuiz, action: { .listeningQuiz($0) }))
+        NavigationStackStore(store.scope(state: \.path, action: \.path)) {
+            ListeningQuizView(store: store.scope(state: \.listeningQuiz, action: \.listeningQuiz))
         } destination: {
             switch $0 {
             case .summary:
@@ -117,7 +117,7 @@ struct ListeningQuizNavigationView: View {
                 )
             }
         }
-        .sheet(store: store.scope(state: \.$settings, action: { .settings($0) })) { store in
+        .sheet(store: store.scope(state: \.$settings, action: \.settings)) { store in
             SettingsView(store: store)
         }
     }

--- a/count/Feature/ListeningQuizNavigationFeature.swift
+++ b/count/Feature/ListeningQuizNavigationFeature.swift
@@ -2,10 +2,10 @@ import ComposableArchitecture
 import SwiftUI
 
 @Reducer struct ListeningQuizNavigationFeature {
-    struct State: Equatable {
+    @ObservableState struct State: Equatable {
         var listeningQuiz: ListeningQuizFeature.State
         var path = StackState<Path.State>()
-        @PresentationState var settings: SettingsFeature.State?
+        @Presents var settings: SettingsFeature.State?
 
         init(topicID: UUID) {
             @Dependency(\.sessionSettingsClient) var sessionSettingsClient

--- a/count/Feature/PreSettingsFeature.swift
+++ b/count/Feature/PreSettingsFeature.swift
@@ -2,7 +2,7 @@ import _NotificationDependency
 import ComposableArchitecture
 import SwiftUI
 
-struct PreSettingsFeature: Reducer {
+@Reducer struct PreSettingsFeature {
     struct State: Equatable {
         @BindingState var rawQuizMode: SessionSettings.QuizMode
         @BindingState var rawQuestionLimit: Int

--- a/count/Feature/SessionSummaryFeature.swift
+++ b/count/Feature/SessionSummaryFeature.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 import SwiftUI
 
 @Reducer struct SessionSummaryFeature {
-    struct State: Equatable {
+    @ObservableState struct State: Equatable {
         let topic: Topic
         let sessionChallenges: [Challenge]
         let quizMode: QuizMode
@@ -17,7 +17,7 @@ import SwiftUI
             self.quizMode = quizMode
             self.isSessionComplete = isSessionComplete
         }
-        
+
         var challengesTotalCount: Int { sessionChallenges.count }
         var challengesCorrectCount: Int { challengesCorrect.count }
         var challengesIncorrectSkippedCount: Int {
@@ -69,164 +69,162 @@ struct SessionSummaryView: View {
     let store: StoreOf<SessionSummaryFeature>
 
     var body: some View {
-        WithViewStore(store, observe: { $0 }) { viewStore in
-            List {
-                Section {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("\(viewStore.topic.skill.title): \(viewStore.topic.category.title)")
-                            .font(.headline)
-                        Text(viewStore.topic.title)
-                            .font(.subheadline)
-                        Text(viewStore.topic.description)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                    .multilineTextAlignment(.leading)
-                    .padding(.vertical, 2)
-                    HStack {
-                        Text("Quiz Mode:")
-                            .foregroundStyle(Color(.secondaryLabel))
-                        Text(viewStore.quizModeTitle)
-                    }
+        List {
+            Section {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("\(store.topic.skill.title): \(store.topic.category.title)")
+                        .font(.headline)
+                    Text(store.topic.title)
+                        .font(.subheadline)
+                    Text(store.topic.description)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .multilineTextAlignment(.leading)
+                .padding(.vertical, 2)
+                HStack {
+                    Text("Quiz Mode:")
+                        .foregroundStyle(Color(.secondaryLabel))
+                    Text(store.quizModeTitle)
+                }
+                .font(.subheadline)
+            } header: {
+                Text("Topic")
                     .font(.subheadline)
-                } header: {
-                    Text("Topic")
-                        .font(.subheadline)
-                }
-
-                Section {
-                    HStack {
-                        Image(systemName: "tray.full")
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(width: 17)
-                        Text("Total Answers")
-                        Spacer()
-                        Text("\(viewStore.challengesTotalCount)")
-                            .font(.headline)
-                    }
-                    .listRowInsets(.init(top: 0, leading: 20, bottom: 0, trailing: 20))
-                    HStack {
-                        Image(systemName: "checkmark.circle")
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(width: 17)
-                            .foregroundStyle(Color.green)
-                        Text("Correct")
-                        Spacer()
-                        Text("\(viewStore.challengesCorrectCount)")
-                            .font(.headline)
-                    }
-                    .listRowInsets(.init(top: 0, leading: 40, bottom: 0, trailing: 20))
-                    HStack {
-                        Image(systemName: "xmark.circle")
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(width: 17)
-                            .foregroundStyle(Color.red)
-                        Text("Incorrect & skipped")
-                        Spacer()
-                        Text("\(viewStore.challengesIncorrectSkippedCount)")
-                            .font(.headline)
-                    }
-                    .listRowInsets(.init(top: 0, leading: 40, bottom: 0, trailing: 20))
-                } header: {
-                    Text("Results")
-                        .font(.subheadline)
-                }
-
-                let skipped = viewStore.state.challengesSkipped
-                if !skipped.isEmpty {
-                    Section {
-                        ForEach(skipped) { challenge in
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(challenge.question.acceptedAnswer)
-                                if !challenge.submissions.filter({ $0.kind != .correct }).isEmpty {
-                                    ViewThatFits {
-                                        HStack {
-                                            ForEach(challenge.submissions) { submission in
-                                                if let value = submission.value {
-                                                    Text(value)
-                                                }
-                                            }
-                                        }
-                                        .strikethrough()
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                        .lineLimit(1)
-
-                                        Text("\(challenge.submissions.count) attempts")
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
-                                    }
-                                }
-                            }
-                        }
-                    } header: {
-                        Text("Skipped Questions")
-                            .font(.subheadline)
-                    }
-                }
-
-                let incorrect = viewStore.state.challengesIncorrect
-                if !incorrect.isEmpty {
-                    Section {
-                        ForEach(incorrect) { challenge in
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(challenge.question.acceptedAnswer)
-                                if !challenge.submissions.filter({ $0.kind != .correct }).isEmpty {
-                                    ViewThatFits {
-                                        HStack {
-                                            ForEach(challenge.submissions) { submission in
-                                                if let value = submission.value, submission.kind != .correct {
-                                                    Text(value)
-                                                }
-                                            }
-                                        }
-                                        .strikethrough()
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                        .lineLimit(1)
-
-                                        Text("\(challenge.submissions.count) attempts")
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
-                                    }
-                                }
-                            }
-                        }
-                    } header: {
-                        Text("Incorrect Questions")
-                            .font(.subheadline)
-                    }
-                }
             }
-            .safeAreaInset(edge: .bottom) {
-                Button {
-                    viewStore.send(.endSessionButtonTapped)
-                } label: {
-                    HStack(spacing: 6) {
-                        Image(systemName: "door.right.hand.open")
-                        Text("Back to Topics")
-                    }
-                    .font(.headline)
-                    .padding(.vertical, 20)
-                    .frame(maxWidth: .infinity)
-                    .background {
-                        RoundedRectangle(cornerRadius: 16.0)
-                            .fill(Color(.tertiarySystemBackground).shadow(.drop(color: Color.black.opacity(0.05), radius: 6)))
-                    }
-                    .padding(.horizontal, 20)
-                }
-                // TODO: Button: retry session with same settings (if timed session was completed)
-            }
-            .navigationBarBackButtonHidden(viewStore.isSessionComplete)
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .principal) {
-                    Text("Session Summary")
+
+            Section {
+                HStack {
+                    Image(systemName: "tray.full")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 17)
+                    Text("Total Answers")
+                    Spacer()
+                    Text("\(store.challengesTotalCount)")
                         .font(.headline)
                 }
+                .listRowInsets(.init(top: 0, leading: 20, bottom: 0, trailing: 20))
+                HStack {
+                    Image(systemName: "checkmark.circle")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 17)
+                        .foregroundStyle(Color.green)
+                    Text("Correct")
+                    Spacer()
+                    Text("\(store.challengesCorrectCount)")
+                        .font(.headline)
+                }
+                .listRowInsets(.init(top: 0, leading: 40, bottom: 0, trailing: 20))
+                HStack {
+                    Image(systemName: "xmark.circle")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 17)
+                        .foregroundStyle(Color.red)
+                    Text("Incorrect & skipped")
+                    Spacer()
+                    Text("\(store.challengesIncorrectSkippedCount)")
+                        .font(.headline)
+                }
+                .listRowInsets(.init(top: 0, leading: 40, bottom: 0, trailing: 20))
+            } header: {
+                Text("Results")
+                    .font(.subheadline)
+            }
+
+            let skipped = store.state.challengesSkipped
+            if !skipped.isEmpty {
+                Section {
+                    ForEach(skipped) { challenge in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(challenge.question.acceptedAnswer)
+                            if !challenge.submissions.filter({ $0.kind != .correct }).isEmpty {
+                                ViewThatFits {
+                                    HStack {
+                                        ForEach(challenge.submissions) { submission in
+                                            if let value = submission.value {
+                                                Text(value)
+                                            }
+                                        }
+                                    }
+                                    .strikethrough()
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+
+                                    Text("\(challenge.submissions.count) attempts")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+                } header: {
+                    Text("Skipped Questions")
+                        .font(.subheadline)
+                }
+            }
+
+            let incorrect = store.state.challengesIncorrect
+            if !incorrect.isEmpty {
+                Section {
+                    ForEach(incorrect) { challenge in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(challenge.question.acceptedAnswer)
+                            if !challenge.submissions.filter({ $0.kind != .correct }).isEmpty {
+                                ViewThatFits {
+                                    HStack {
+                                        ForEach(challenge.submissions) { submission in
+                                            if let value = submission.value, submission.kind != .correct {
+                                                Text(value)
+                                            }
+                                        }
+                                    }
+                                    .strikethrough()
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+
+                                    Text("\(challenge.submissions.count) attempts")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+                } header: {
+                    Text("Incorrect Questions")
+                        .font(.subheadline)
+                }
+            }
+        }
+        .safeAreaInset(edge: .bottom) {
+            Button {
+                store.send(.endSessionButtonTapped)
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "door.right.hand.open")
+                    Text("Back to Topics")
+                }
+                .font(.headline)
+                .padding(.vertical, 20)
+                .frame(maxWidth: .infinity)
+                .background {
+                    RoundedRectangle(cornerRadius: 16.0)
+                        .fill(Color(.tertiarySystemBackground).shadow(.drop(color: Color.black.opacity(0.05), radius: 6)))
+                }
+                .padding(.horizontal, 20)
+            }
+            // TODO: Button: retry session with same settings (if timed session was completed)
+        }
+        .navigationBarBackButtonHidden(store.isSessionComplete)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                Text("Session Summary")
+                    .font(.headline)
             }
         }
     }

--- a/count/Feature/SessionSummaryFeature.swift
+++ b/count/Feature/SessionSummaryFeature.swift
@@ -1,7 +1,7 @@
 import ComposableArchitecture
 import SwiftUI
 
-struct SessionSummaryFeature: Reducer {
+@Reducer struct SessionSummaryFeature {
     struct State: Equatable {
         let topic: Topic
         let sessionChallenges: [Challenge]
@@ -16,6 +16,34 @@ struct SessionSummaryFeature: Reducer {
 
             self.quizMode = quizMode
             self.isSessionComplete = isSessionComplete
+        }
+        
+        var challengesTotalCount: Int { sessionChallenges.count }
+        var challengesCorrectCount: Int { challengesCorrect.count }
+        var challengesIncorrectSkippedCount: Int {
+            sessionChallenges
+                .filter { $0.submissions.contains(where: { $0.kind == .incorrect || $0.kind == .skip }) }
+                .count
+        }
+
+        var challengesCorrect: [Challenge] {
+            sessionChallenges.filter { $0.submissions.allSatisfy { $0.kind == .correct } }
+        }
+        var challengesSkipped: [Challenge] {
+            sessionChallenges.filter { $0.submissions.contains(where: { $0.kind == .skip }) }
+        }
+        var challengesIncorrect: [Challenge] {
+            sessionChallenges.filter { !$0.submissions.contains(where: { $0.kind == .skip }) && $0.submissions.contains(where: { $0.kind == .incorrect }) }
+        }
+        var quizModeTitle: String {
+            switch quizMode {
+            case .infinite:
+                "Infinite"
+            case let .questionLimit(limit):
+                "\(limit) question limit"
+            case let .timeLimit(limit):
+                "\(Duration.seconds(limit).formatted(.units(width: .abbreviated))) limit"
+            }
         }
     }
 
@@ -33,36 +61,6 @@ struct SessionSummaryFeature: Reducer {
                     await haptics.success()
                 }
             }
-        }
-    }
-}
-
-extension SessionSummaryFeature.State {
-    var challengesTotalCount: Int { sessionChallenges.count }
-    var challengesCorrectCount: Int { challengesCorrect.count }
-    var challengesIncorrectSkippedCount: Int {
-        sessionChallenges
-            .filter { $0.submissions.contains(where: { $0.kind == .incorrect || $0.kind == .skip }) }
-            .count
-    }
-
-    var challengesCorrect: [Challenge] {
-        sessionChallenges.filter { $0.submissions.allSatisfy { $0.kind == .correct } }
-    }
-    var challengesSkipped: [Challenge] {
-        sessionChallenges.filter { $0.submissions.contains(where: { $0.kind == .skip }) }
-    }
-    var challengesIncorrect: [Challenge] {
-        sessionChallenges.filter { !$0.submissions.contains(where: { $0.kind == .skip }) && $0.submissions.contains(where: { $0.kind == .incorrect }) }
-    }
-    var quizModeTitle: String {
-        switch quizMode {
-        case .infinite:
-            "Infinite"
-        case let .questionLimit(limit):
-            "\(limit) question limit"
-        case let .timeLimit(limit):
-            "\(Duration.seconds(limit).formatted(.units(width: .abbreviated))) limit"
         }
     }
 }

--- a/count/Feature/SettingsFeature.swift
+++ b/count/Feature/SettingsFeature.swift
@@ -1,7 +1,7 @@
 import ComposableArchitecture
 import SwiftUI
 
-struct SettingsFeature: Reducer {
+@Reducer struct SettingsFeature {
     struct State: Equatable {
         @BindingState var sessionSettings: SessionSettings
         let topic: Topic

--- a/count/Feature/SettingsFeature.swift
+++ b/count/Feature/SettingsFeature.swift
@@ -2,8 +2,8 @@ import ComposableArchitecture
 import SwiftUI
 
 @Reducer struct SettingsFeature {
-    struct State: Equatable {
-        @BindingState var sessionSettings: SessionSettings
+    @ObservableState struct State: Equatable {
+        var sessionSettings: SessionSettings
         let topic: Topic
 
         init(topicID: UUID) {
@@ -60,63 +60,61 @@ import SwiftUI
 }
 
 struct SettingsView: View {
-    let store: StoreOf<SettingsFeature>
+    @Bindable var store: StoreOf<SettingsFeature>
 
     var body: some View {
-        WithViewStore(store, observe: { $0 }) { viewStore in
-            NavigationStack {
-                Form {
-                    Section {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("\(viewStore.topic.skill.title): \(viewStore.topic.category.title)")
-                                .font(.headline)
-                            Text(viewStore.topic.title)
-                                .font(.subheadline)
-                            Text(viewStore.topic.description)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                        .multilineTextAlignment(.leading)
-                        .padding(.vertical, 2)
-                    } header: {
-                        Text("Topic")
-                            .font(.subheadline)
-                    }
-
-                    Section {
-                        Toggle(isOn: viewStore.$sessionSettings.isShowingProgress, label: {
-                            Text("Show progress")
-                        })
-                        Toggle(isOn: viewStore.$sessionSettings.isShowingBiki, label: {
-                            Text("Show Biki")
-                        })
-                        Toggle(isOn: viewStore.$sessionSettings.isShowingConfetti, label: {
-                            Text("Show confetti")
-                        })
-                    } header: {
-                        Text("Display Settings")
-                            .font(.subheadline)
-                    }
-
-                    SpeechSettingsSection(
-                        store: Store(initialState: .init()) {
-                            SpeechSettingsFeature()
-                        })
-                }
-                .navigationBarTitleDisplayMode(.inline)
-                .navigationTitle("Session")
-                .toolbar {
-                    ToolbarItem(placement: .principal) {
-                        Text("Session")
+        NavigationStack {
+            Form {
+                Section {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("\(store.topic.skill.title): \(store.topic.category.title)")
                             .font(.headline)
+                        Text(store.topic.title)
+                            .font(.subheadline)
+                        Text(store.topic.description)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                     }
-                    ToolbarItem(placement: .primaryAction) {
-                        Button {
-                            viewStore.send(.doneButtonTapped)
-                        } label: {
-                            Text("Done")
-                                .font(.headline)
-                        }
+                    .multilineTextAlignment(.leading)
+                    .padding(.vertical, 2)
+                } header: {
+                    Text("Topic")
+                        .font(.subheadline)
+                }
+
+                Section {
+                    Toggle(isOn: $store.sessionSettings.isShowingProgress, label: {
+                        Text("Show progress")
+                    })
+                    Toggle(isOn: $store.sessionSettings.isShowingBiki, label: {
+                        Text("Show Biki")
+                    })
+                    Toggle(isOn: $store.sessionSettings.isShowingConfetti, label: {
+                        Text("Show confetti")
+                    })
+                } header: {
+                    Text("Display Settings")
+                        .font(.subheadline)
+                }
+
+                SpeechSettingsSection(
+                    store: Store(initialState: .init()) {
+                        SpeechSettingsFeature()
+                    })
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationTitle("Session")
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    Text("Session")
+                        .font(.headline)
+                }
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        store.send(.doneButtonTapped)
+                    } label: {
+                        Text("Done")
+                            .font(.headline)
                     }
                 }
             }

--- a/count/Feature/SpeechSettingsFeature.swift
+++ b/count/Feature/SpeechSettingsFeature.swift
@@ -2,7 +2,7 @@ import _NotificationDependency
 import ComposableArchitecture
 import SwiftUI
 
-struct SpeechSettingsFeature: Reducer {
+@Reducer struct SpeechSettingsFeature {
     struct State: Equatable {
         var availableVoices: [SpeechSynthesisVoice]
         @BindingState var rawSpeechRate: Float

--- a/count/Feature/TextSpeechFeature.swift
+++ b/count/Feature/TextSpeechFeature.swift
@@ -2,7 +2,7 @@ import Collections
 import ComposableArchitecture
 import SwiftUI
 
-struct TextSpeechFeature: Reducer {
+@Reducer struct TextSpeechFeature {
     struct State: Equatable {
         @BindingState var textValue: String = ""
         var submissions: OrderedSet<String> = []

--- a/count/Feature/TextSpeechFeature.swift
+++ b/count/Feature/TextSpeechFeature.swift
@@ -3,8 +3,8 @@ import ComposableArchitecture
 import SwiftUI
 
 @Reducer struct TextSpeechFeature {
-    struct State: Equatable {
-        @BindingState var textValue: String = ""
+    @ObservableState struct State: Equatable {
+        var textValue: String = ""
         var submissions: OrderedSet<String> = []
     }
 
@@ -63,82 +63,80 @@ import SwiftUI
 }
 
 struct TextSpeechView: View {
-    let store: StoreOf<TextSpeechFeature>
+    @Bindable var store: StoreOf<TextSpeechFeature>
     @FocusState private var textFieldFocused: Bool
 
     var body: some View {
-        WithViewStore(store, observe: { $0 }) { viewStore in
-            VStack {
-                List(viewStore.submissions, id: \.self) { submission in
+        VStack {
+            List(store.submissions, id: \.self) { submission in
+                Button {
+                    store.send(.submissionTapped(submission))
+                } label: {
+                    HStack {
+                        Image(systemName: "chevron.right")
+                            .padding(.trailing)
+                        Text(submission)
+                            .font(.headline)
+                    }
+                }
+                .contextMenu {
+                    Button("Play") {
+                        store.send(.playButtonTapped(submission))
+                    }
+                    Button("Delete", role: .destructive) {
+                        store.send(.onDelete(submission))
+                    }
+                }
+            }
+            .listStyle(.plain)
+        }
+        .safeAreaInset(edge: .bottom) {
+            VStack(spacing: 16) {
+                HStack {
+                    ForEach(["日", "月", "ヶ月", "年", "間"], id: \.self) { character in
+                        Button(character) {
+                            store.send(.appendStringButtonTapped(character))
+                        }
+                    }
                     Button {
-                        viewStore.send(.submissionTapped(submission))
+                        store.send(.clearButtonTapped)
                     } label: {
-                        HStack {
-                            Image(systemName: "chevron.right")
-                                .padding(.trailing)
-                            Text(submission)
-                                .font(.headline)
-                        }
-                    }
-                    .contextMenu {
-                        Button("Play") {
-                            viewStore.send(.playButtonTapped(submission))
-                        }
-                        Button("Delete", role: .destructive) {
-                            viewStore.send(.onDelete(submission))
-                        }
+                        Image(systemName: "xmark.circle")
                     }
                 }
-                .listStyle(.plain)
-            }
-            .safeAreaInset(edge: .bottom) {
-                VStack(spacing: 16) {
-                    HStack {
-                        ForEach(["日", "月", "ヶ月", "年", "間"], id: \.self) { character in
-                            Button(character) {
-                                viewStore.send(.appendStringButtonTapped(character))
-                            }
-                        }
-                        Button {
-                            viewStore.send(.clearButtonTapped)
-                        } label: {
-                            Image(systemName: "xmark.circle")
-                        }
-                    }
-                    .padding(.horizontal)
-                    .buttonStyle(.bordered)
-                    HStack {
-                        TextField("Text-to-speech", text: viewStore.$textValue)
-                            .foregroundStyle(Color.primary)
-                            .font(.largeTitle)
-                            .bold()
-                            .textFieldStyle(.plain)
-                            .keyboardType(.default)
-                            .padding(.horizontal, 4)
-                            .focused($textFieldFocused)
+                .padding(.horizontal)
+                .buttonStyle(.bordered)
+                HStack {
+                    TextField("Text-to-speech", text: $store.textValue)
+                        .foregroundStyle(Color.primary)
+                        .font(.largeTitle)
+                        .bold()
+                        .textFieldStyle(.plain)
+                        .keyboardType(.default)
+                        .padding(.horizontal, 4)
+                        .focused($textFieldFocused)
 
-                        Spacer().frame(width: 16)
+                    Spacer().frame(width: 16)
 
-                        Button {
-                            viewStore.send(.submitButtonTapped)
-                        } label: {
-                            Image(systemName: "play.fill")
-                                .font(.title)
-                        }
-                        .buttonStyle(.borderedProminent)
+                    Button {
+                        store.send(.submitButtonTapped)
+                    } label: {
+                        Image(systemName: "play.fill")
+                            .font(.title)
                     }
-                }
-                .padding()
-                .background {
-                    Color(.secondarySystemBackground)
-                        .ignoresSafeArea(.all, edges: .bottom)
-                        .shadow(color: Color.primary.opacity(0.15), radius: 3, x: 0, y: 0)
+                    .buttonStyle(.borderedProminent)
                 }
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .onAppear {
-                textFieldFocused = true
+            .padding()
+            .background {
+                Color(.secondarySystemBackground)
+                    .ignoresSafeArea(.all, edges: .bottom)
+                    .shadow(color: Color.primary.opacity(0.15), radius: 3, x: 0, y: 0)
             }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onAppear {
+            textFieldFocused = true
         }
     }
 }

--- a/count/Feature/TopicsFeature.swift
+++ b/count/Feature/TopicsFeature.swift
@@ -41,30 +41,10 @@ extension TopicCategory {
         case setDestination(Destination.State)
     }
 
-    @Reducer struct Destination {
-        enum State: Equatable, Sendable {
-            case preSettings(PreSettingsFeature.State)
-            case quiz(ListeningQuizNavigationFeature.State)
-            case about(AboutFeature.State)
-        }
-
-        enum Action: Equatable, Sendable {
-            case preSettings(PreSettingsFeature.Action)
-            case quiz(ListeningQuizNavigationFeature.Action)
-            case about(AboutFeature.Action)
-        }
-
-        var body: some ReducerOf<Self> {
-            Scope(state: \.preSettings, action: \.preSettings) {
-                PreSettingsFeature()
-            }
-            Scope(state: \.quiz, action: \.quiz) {
-                ListeningQuizNavigationFeature()
-            }
-            Scope(state: \.about, action: \.about) {
-                AboutFeature()
-            }
-        }
+    @Reducer(state: .equatable, action: .equatable) enum Destination {
+        case preSettings(PreSettingsFeature)
+        case quiz(ListeningQuizNavigationFeature)
+        case about(AboutFeature)
     }
 
     @Dependency(\.continuousClock) var clock
@@ -99,14 +79,12 @@ extension TopicCategory {
                 }
             }
         }
-        .ifLet(\.$destination, action: \.destination) {
-            Destination()
-        }
+        .ifLet(\.$destination, action: \.destination)
     }
 }
 
 struct TopicsView: View {
-    let store: StoreOf<TopicsFeature>
+    @Bindable var store: StoreOf<TopicsFeature>
     let isFavoritesEnabled: Bool = false
 
     var body: some View {
@@ -202,13 +180,13 @@ struct TopicsView: View {
                 }
             }
         }
-        .fullScreenCover(store: store.scope(state: \.$destination.quiz, action: \.destination.quiz)) { store in
+        .fullScreenCover(item: $store.scope(state: \.destination?.quiz, action: \.destination.quiz)) { store in
             ListeningQuizNavigationView(store: store)
         }
-        .sheet(store: store.scope(state: \.$destination.about, action: \.destination.about)) { store in
+        .sheet(item: $store.scope(state: \.destination?.about, action: \.destination.about)) { store in
             AboutView(store: store)
         }
-        .sheet(store: store.scope(state: \.$destination.preSettings, action: \.destination.preSettings)) { store in
+        .sheet(item: $store.scope(state: \.destination?.preSettings, action: \.destination.preSettings)) { store in
             PreSettingsView(store: store)
                 .presentationDragIndicator(.visible)
                 .presentationDetents([.fraction(0.1), .medium, .large])

--- a/count/Feature/TopicsFeature.swift
+++ b/count/Feature/TopicsFeature.swift
@@ -203,25 +203,13 @@ struct TopicsView: View {
                     }
                 }
             }
-            .fullScreenCover(
-                store: store.scope(state: \.$destination, action: \.destination),
-                state: /TopicsFeature.Destination.State.quiz,
-                action: TopicsFeature.Destination.Action.quiz
-            ) { store in
+            .fullScreenCover(store: store.scope(state: \.$destination.quiz, action: \.destination.quiz)) { store in
                 ListeningQuizNavigationView(store: store)
             }
-            .sheet(
-                store: store.scope(state: \.$destination, action: \.destination),
-                state: /TopicsFeature.Destination.State.about,
-                action: TopicsFeature.Destination.Action.about
-            ) { store in
+            .sheet(store: store.scope(state: \.$destination.about, action: \.destination.about)) { store in
                 AboutView(store: store)
             }
-            .sheet(
-                store: store.scope(state: \.$destination, action: \.destination),
-                state: /TopicsFeature.Destination.State.preSettings,
-                action: TopicsFeature.Destination.Action.preSettings
-            ) { store in
+            .sheet(store: store.scope(state: \.$destination.preSettings, action: \.destination.preSettings)) { store in
                 PreSettingsView(store: store)
                     .presentationDragIndicator(.visible)
                     .presentationDetents([.fraction(0.1), .medium, .large])

--- a/count/Feature/TopicsFeature.swift
+++ b/count/Feature/TopicsFeature.swift
@@ -17,7 +17,7 @@ extension TopicCategory {
     }
 }
 
-struct TopicsFeature: Reducer {
+@Reducer struct TopicsFeature {
     struct State: Equatable {
         @PresentationState var destination: Destination.State?
         let listeningCategories: IdentifiedArrayOf<TopicCategory>

--- a/count/Feature/TopicsFeature.swift
+++ b/count/Feature/TopicsFeature.swift
@@ -99,7 +99,7 @@ extension TopicCategory {
                 }
             }
         }
-        .ifLet(\.$destination, action: /Action.destination) {
+        .ifLet(\.$destination, action: \.destination) {
             Destination()
         }
     }

--- a/count/Feature/TopicsFeature.swift
+++ b/count/Feature/TopicsFeature.swift
@@ -41,7 +41,7 @@ extension TopicCategory {
         case setDestination(Destination.State)
     }
 
-    struct Destination: Reducer {
+    @Reducer struct Destination {
         enum State: Equatable, Sendable {
             case preSettings(PreSettingsFeature.State)
             case quiz(ListeningQuizNavigationFeature.State)
@@ -55,13 +55,13 @@ extension TopicCategory {
         }
 
         var body: some ReducerOf<Self> {
-            Scope(state: /State.preSettings, action: /Action.preSettings) {
+            Scope(state: \.preSettings, action: \.preSettings) {
                 PreSettingsFeature()
             }
-            Scope(state: /State.quiz, action: /Action.quiz) {
+            Scope(state: \.quiz, action: \.quiz) {
                 ListeningQuizNavigationFeature()
             }
-            Scope(state: /State.about, action: /Action.about) {
+            Scope(state: \.about, action: \.about) {
                 AboutFeature()
             }
         }
@@ -204,21 +204,21 @@ struct TopicsView: View {
                 }
             }
             .fullScreenCover(
-                store: store.scope(state: \.$destination, action: { .destination($0) }),
+                store: store.scope(state: \.$destination, action: \.destination),
                 state: /TopicsFeature.Destination.State.quiz,
                 action: TopicsFeature.Destination.Action.quiz
             ) { store in
                 ListeningQuizNavigationView(store: store)
             }
             .sheet(
-                store: store.scope(state: \.$destination, action: { .destination($0) }),
+                store: store.scope(state: \.$destination, action: \.destination),
                 state: /TopicsFeature.Destination.State.about,
                 action: TopicsFeature.Destination.Action.about
             ) { store in
                 AboutView(store: store)
             }
             .sheet(
-                store: store.scope(state: \.$destination, action: { .destination($0) }),
+                store: store.scope(state: \.$destination, action: \.destination),
                 state: /TopicsFeature.Destination.State.preSettings,
                 action: TopicsFeature.Destination.Action.preSettings
             ) { store in

--- a/count/Feature/TranslyvaniaTierFeature.swift
+++ b/count/Feature/TranslyvaniaTierFeature.swift
@@ -181,7 +181,7 @@ struct TranslyvaniaTierView: View {
                                 )
                                 .disabled(viewStore.isPurchasingProductId != nil)
                             }
-                            .alert(store: store.scope(state: \.$alert, action: { .alert($0) }))
+                            .alert(store: store.scope(state: \.$alert, action: \.alert))
                             HStack(spacing: 20) {
                                 Button {
                                     viewStore.send(.restorePurchasesTapped)

--- a/count/Feature/TranslyvaniaTierFeature.swift
+++ b/count/Feature/TranslyvaniaTierFeature.swift
@@ -115,7 +115,7 @@ import SwiftUI
 }
 
 struct TranslyvaniaTierView: View {
-    let store: StoreOf<TransylvaniaTierFeature>
+    @Bindable var store: StoreOf<TransylvaniaTierFeature>
 
     var body: some View {
         ScrollView {
@@ -180,7 +180,7 @@ struct TranslyvaniaTierView: View {
                             )
                             .disabled(store.isPurchasingProductId != nil)
                         }
-                        .alert(store: store.scope(state: \.$alert, action: \.alert))
+                        .alert($store.scope(state: \.alert, action: \.alert))
                         HStack(spacing: 20) {
                             Button {
                                 store.send(.restorePurchasesTapped)

--- a/count/Feature/TranslyvaniaTierFeature.swift
+++ b/count/Feature/TranslyvaniaTierFeature.swift
@@ -1,7 +1,7 @@
 import ComposableArchitecture
 import SwiftUI
 
-struct TransylvaniaTierFeature: Reducer {
+@Reducer struct TransylvaniaTierFeature {
     struct State: Equatable, Sendable {
         @PresentationState var alert: AlertState<Never>?
         var tierHistory: TierPurchaseHistory

--- a/count/Feature/TranslyvaniaTierFeature.swift
+++ b/count/Feature/TranslyvaniaTierFeature.swift
@@ -2,8 +2,8 @@ import ComposableArchitecture
 import SwiftUI
 
 @Reducer struct TransylvaniaTierFeature {
-    struct State: Equatable, Sendable {
-        @PresentationState var alert: AlertState<Never>?
+    @ObservableState struct State: Equatable, Sendable {
+        @Presents var alert: AlertState<Never>?
         var tierHistory: TierPurchaseHistory
         var availableProducts: DataState<IdentifiedArrayOf<TierProduct>> = .initialized
         var confettiAnimation: Int = 0
@@ -118,104 +118,102 @@ struct TranslyvaniaTierView: View {
     let store: StoreOf<TransylvaniaTierFeature>
 
     var body: some View {
-        WithViewStore(store, observe: { $0 }) { viewStore in
-            ScrollView {
-                VStack(spacing: 20) {
-                    VStack(spacing: 10) {
-                        Text(viewStore.hasTranslyvaniaTier ? "You've unlocked..." : "Leave any size tip to unlock...")
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                        Text("Translyvania Tier")
-                            .font(.largeTitle)
-                            .fontWeight(.black)
-                            .foregroundStyle(LinearGradient(colors: [Color.red, Color.orange, Color.yellow], startPoint: .bottomLeading, endPoint: .topTrailing))
-                            .confettiCannon(counter: .constant(viewStore.confettiAnimation), num: 85, confettiSize: 7, rainHeight: 1000, fadesOut: false, opacity: 1.0, openingAngle: .degrees(20), closingAngle: .degrees(160), radius: 180, repetitions: 0, repetitionInterval: 2.0)
-                        if viewStore.hasTranslyvaniaTier {
-                            Text("Thanks for supporting development")
-                                .fontDesign(.default)
-                                .italic()
-                        }
-                        VStack(alignment: .leading, spacing: 10) {
-                            Text("\(Image(systemName: "1.circle"))  Choose your favorite app icon")
-                            Text("\(Image(systemName: "2.circle"))  Support ongoing development")
-                        }
-                        .font(.headline)
-                        .padding(.trailing, 20)
-                        .padding(.vertical, 16)
-                        .frame(maxWidth: .infinity, alignment: .center)
+        ScrollView {
+            VStack(spacing: 20) {
+                VStack(spacing: 10) {
+                    Text(store.hasTranslyvaniaTier ? "You've unlocked..." : "Leave any size tip to unlock...")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Text("Translyvania Tier")
+                        .font(.largeTitle)
+                        .fontWeight(.black)
+                        .foregroundStyle(LinearGradient(colors: [Color.red, Color.orange, Color.yellow], startPoint: .bottomLeading, endPoint: .topTrailing))
+                        .confettiCannon(counter: .constant(store.confettiAnimation), num: 85, confettiSize: 7, rainHeight: 1000, fadesOut: false, opacity: 1.0, openingAngle: .degrees(20), closingAngle: .degrees(160), radius: 180, repetitions: 0, repetitionInterval: 2.0)
+                    if store.hasTranslyvaniaTier {
+                        Text("Thanks for supporting development")
+                            .fontDesign(.default)
+                            .italic()
                     }
-                    .animation(.default, value: viewStore.hasTranslyvaniaTier)
-                    if viewStore.availableProducts.isLoading {
-                        ProgressView().padding()
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("\(Image(systemName: "1.circle"))  Choose your favorite app icon")
+                        Text("\(Image(systemName: "2.circle"))  Support ongoing development")
                     }
-                    if let error = viewStore.availableProducts.errorMessage {
-                        GroupBox {
-                            Text(error)
-                                .font(.headline)
-                                .multilineTextAlignment(.center)
-                                .foregroundStyle(.red)
-                                .padding()
-                                .frame(maxWidth: .infinity)
-                            Button("Try Again") {
-                                viewStore.send(.retryLoadProductsTapped)
-                            }
-                            .buttonStyle(.bordered)
+                    .font(.headline)
+                    .padding(.trailing, 20)
+                    .padding(.vertical, 16)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                }
+                .animation(.default, value: store.hasTranslyvaniaTier)
+                if store.availableProducts.isLoading {
+                    ProgressView().padding()
+                }
+                if let error = store.availableProducts.errorMessage {
+                    GroupBox {
+                        Text(error)
+                            .font(.headline)
+                            .multilineTextAlignment(.center)
+                            .foregroundStyle(.red)
+                            .padding()
+                            .frame(maxWidth: .infinity)
+                        Button("Try Again") {
+                            store.send(.retryLoadProductsTapped)
                         }
+                        .buttonStyle(.bordered)
                     }
-                    if let availableProducts = viewStore.availableProducts.value {
-                        let productCounts = viewStore.tierHistory.productCounts
-                        VStack(spacing: 16) {
-                            ForEach(availableProducts) { product in
-                                let count = productCounts[product.id] ?? 0
-                                TipButton(
-                                    imageName: nil,
-                                    title: product.item?.title,
-                                    subtitle: product.displayName,
-                                    description: product.item?.description,
-                                    price: product.displayPrice,
-                                    purchaseCount: (count > 0) ? "\(count)" : nil,
-                                    isBeingPurchased: product.id == viewStore.isPurchasingProductId,
-                                    action: {
-                                        viewStore.send(.purchaseButtonTapped(product))
-                                    }
-                                )
-                                .disabled(viewStore.isPurchasingProductId != nil)
-                            }
-                            .alert(store: store.scope(state: \.$alert, action: \.alert))
-                            HStack(spacing: 20) {
-                                Button {
-                                    viewStore.send(.restorePurchasesTapped)
-                                } label: {
-                                    Text("Restore Purchases")
-                                        .font(.callout)
+                }
+                if let availableProducts = store.availableProducts.value {
+                    let productCounts = store.tierHistory.productCounts
+                    VStack(spacing: 16) {
+                        ForEach(availableProducts) { product in
+                            let count = productCounts[product.id] ?? 0
+                            TipButton(
+                                imageName: nil,
+                                title: product.item?.title,
+                                subtitle: product.displayName,
+                                description: product.item?.description,
+                                price: product.displayPrice,
+                                purchaseCount: (count > 0) ? "\(count)" : nil,
+                                isBeingPurchased: product.id == store.isPurchasingProductId,
+                                action: {
+                                    store.send(.purchaseButtonTapped(product))
                                 }
-                                Link("Privacy Policy", destination: GlobalURL.privacyPolicy)
+                            )
+                            .disabled(store.isPurchasingProductId != nil)
+                        }
+                        .alert(store: store.scope(state: \.$alert, action: \.alert))
+                        HStack(spacing: 20) {
+                            Button {
+                                store.send(.restorePurchasesTapped)
+                            } label: {
+                                Text("Restore Purchases")
                                     .font(.callout)
                             }
-                            .padding(.vertical, 0)
-                            #if DEBUG
-                                Button {
-                                    viewStore.send(.clearPurchaseHistory)
-                                } label: {
-                                    Text("[DEBUG] Clear Purchase History")
-                                        .font(.callout)
-                                }
-                            #endif
+                            Link("Privacy Policy", destination: GlobalURL.privacyPolicy)
+                                .font(.callout)
                         }
+                        .padding(.vertical, 0)
+                        #if DEBUG
+                            Button {
+                                store.send(.clearPurchaseHistory)
+                            } label: {
+                                Text("[DEBUG] Clear Purchase History")
+                                    .font(.callout)
+                            }
+                        #endif
                     }
                 }
-                .padding()
             }
-            .navigationTitle("Translyvania Tier")
-            .toolbar {
-                ToolbarItem(placement: .principal) {
-                    Text("")
-                }
+            .padding()
+        }
+        .navigationTitle("Translyvania Tier")
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                Text("")
             }
-            .toolbarBackground(.hidden, for: .navigationBar)
-            .task {
-                await viewStore.send(.onTask).finish()
-            }
+        }
+        .toolbarBackground(.hidden, for: .navigationBar)
+        .task {
+            await store.send(.onTask).finish()
         }
     }
 }

--- a/count/Feature/TranslyvaniaTierFeature.swift
+++ b/count/Feature/TranslyvaniaTierFeature.swift
@@ -88,7 +88,7 @@ import SwiftUI
                 }
             }
         }
-        .ifLet(\.$alert, action: /Action.alert)
+        .ifLet(\.$alert, action: \.alert)
     }
 
     private func loadProducts(send: Send<TransylvaniaTierFeature.Action>) async {

--- a/count/View/CountBikiView.swift
+++ b/count/View/CountBikiView.swift
@@ -1,8 +1,8 @@
 import SceneKit
 import SwiftUI
 
-@MainActor struct CountBikiView: View {
-    @MainActor struct SceneState {
+struct CountBikiView: View {
+    struct SceneState {
         let scene: SCNScene
         let catalogName = "CountBiki.scnassets"
 
@@ -10,19 +10,19 @@ import SwiftUI
             scene = .init(named: "\(catalogName)/count_biki_rig.scn")!
         }
 
-        func playIdle() {
+        @MainActor func playIdle() {
             Self.playAnimation(scene: scene, resourceName: "\(catalogName)/count_biki_anim_idle", isLooped: true)
         }
 
-        func playCorrect() {
+        @MainActor func playCorrect() {
             Self.playAnimation(scene: scene, resourceName: "\(catalogName)/count_biki_anim_correct", isLooped: false)
         }
 
-        func playIncorrect() {
+        @MainActor func playIncorrect() {
             Self.playAnimation(scene: scene, resourceName: "\(catalogName)/count_biki_anim_incorrect", isLooped: false)
         }
 
-        static func playAnimation(scene: SCNScene, resourceName: String, isLooped: Bool = false) {
+        @MainActor static func playAnimation(scene: SCNScene, resourceName: String, isLooped: Bool = false) {
             guard let sceneURL = Bundle.main.url(forResource: resourceName, withExtension: "dae") else {
                 assertionFailure("\(resourceName).dae file not found")
                 return

--- a/count/View/CountBikiView.swift
+++ b/count/View/CountBikiView.swift
@@ -76,8 +76,10 @@ struct CountBikiView: View {
             updateSceneBackground(colorScheme)
             sceneState.playIdle()
         }
-        .onChange(of: colorScheme, perform: updateSceneBackground)
-        .onChange(of: bikiAnimation) { newValue in
+        .onChange(of: colorScheme) { _, newValue in
+            updateSceneBackground(newValue)
+        }
+        .onChange(of: bikiAnimation) { _, newValue in
             switch newValue?.kind {
             case .correct:
                 sceneState.playCorrect()

--- a/countTests/ListeningQuizFeatureTests.swift
+++ b/countTests/ListeningQuizFeatureTests.swift
@@ -15,10 +15,10 @@ struct RandomNumberGeneratorWithSeed: RandomNumberGenerator {
     }
 }
 
-@MainActor final class ListeningQuizFeatureTests: XCTestCase {
+final class ListeningQuizFeatureTests: XCTestCase {
     func testOnAppear() async throws {
         let speechExpectation = expectation(description: "speaks")
-        let store = TestStore(initialState: ListeningQuizFeature.State(topicID: Topic.mockID, speechSettings: .mock)) {
+      let store = TestStore(initialState: ListeningQuizFeature.State(topicID: Topic.mockID, quizMode: .infinite)) {
             ListeningQuizFeature()
         } withDependencies: {
             $0.topicClient = .mock


### PR DESCRIPTION
## Xcode 15.3 and Swift 5.10

Some new weird concurrency warnings. See more below.

## iOS 17

It's time to bump the deployment target to iOS 17. I think v1.2.1 is stable enough to use on iOS 16 going forward.

The only real reasoning behind the version bump now is:

1. Not have to worry about `WithPerceptionTracking` in the TCA observable stuff.
2. Be able to use iOS 17 APIs in the near future.

## TCA

We're migrating from 1.3 to 1.9, just before the `Shared` property wrapper.

- The biggest change is `@ObservableState` and removing `WithViewStore`.
- Adding the `Reducer` macro enables using other syntax cleanups across the board.

## Warnings

⚠️ There are now about 60 warnings, most to do with KeyPaths.

From what I see, all these _should_ be fixed by the Swift/Apple teams at some point so, as annoying as they are, the best I can do is ignore them.

